### PR TITLE
Fix Sveltia OAuth: remove Decap-style auth_type config

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,9 +2,6 @@ backend:
   name: github
   repo: d3i-website/d3i-website.github.io
   branch: main
-  auth_type: implicit
-  base_url: https://api.netlify.com
-  auth_endpoint: auth
 
 publish_mode: editorial_workflow
 


### PR DESCRIPTION
Sveltia CMS rejects auth_type: implicit with the error "The configured authentication method (implicit flow) is not supported in Sveltia CMS. Use PKCE authorization instead."

Sveltia's default for backend: github with Netlify's OAuth provider is authorization code flow — and it requires no configuration. Removing auth_type, base_url, and auth_endpoint restores the default flow.