### PR TITLE
Switch CMS commits to cms-staging branch

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
   repo: d3i-website/d3i-website.github.io
-  branch: main
+  branch: cms-staging
 
 publish_mode: editorial_workflow
 


### PR DESCRIPTION
Sveltia's editorial_workflow feature is unimplemented (per their docs, planned for 1.0). Without it, every CMS save commits directly to main — noisy history, one email per edit.

Workaround: point Sveltia at a separate cms-staging branch. CMS edits accumulate there without triggering deploys or emails. Manual merge cms-staging → main batches edits into one clean squash-commit per editorial session, restoring the intended "clean main, bounded email cost" model.

Requires: cms-staging branch must exist on origin before this config takes effect (Sveltia errors out on missing branch).