### PR TITLE
Embed script selector at /software/script-selector/Script selector embed

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -60,6 +60,8 @@ software:
         url: /software/getting-started/
       - title: Ready-made scripts
         url: /software/ready-made-scripts/
+      - title: Script selector
+        url: /software/script-selector/
       - title: Going further
         url: /software/going-further/
       - title: Port in education

--- a/_data/script_selector.yml
+++ b/_data/script_selector.yml
@@ -1,0 +1,23 @@
+# Toggle the entire embed off (renders fallback at build time).
+# Use this for known/extended outages.
+available: true
+
+# URL of the script selector. Update when the workspace moves.
+url: "https://sramtest.d3idatadonation.src.surf-hosted.nl/select"
+
+# Shown above the iframe. Sets expectations for active development.
+banner: >-
+  Preview — this selector is in active development.
+  If it stops responding, try refreshing the page.
+
+# Shown when build-time `available: false` OR the JS timeout fires.
+fallback:
+  heading: "Script selector unavailable"
+  message: >-
+    The script selector is temporarily offline.
+    It's typically back within a few minutes — please try again shortly,
+    or contact us if the problem persists.
+
+# How long the iframe has to fire `load` before we swap to fallback.
+# 8 seconds covers slow workspace cold-starts; faster than the user gives up.
+timeout_seconds: 8

--- a/_data/script_selector.yml
+++ b/_data/script_selector.yml
@@ -5,17 +5,12 @@ available: true
 # URL of the script selector. Update when the workspace moves.
 url: "https://sramtest.d3idatadonation.src.surf-hosted.nl/select"
 
-# Shown above the iframe. Sets expectations for active development.
-banner: >-
-  Preview — this selector is in active development.
-  If it stops responding, try refreshing the page.
-
 # Shown when build-time `available: false` OR the JS timeout fires.
 fallback:
   heading: "Script selector unavailable"
   message: >-
     The script selector is temporarily offline.
-    It's typically back within a few minutes — please try again shortly,
+    It's typically back within a few minutes; please try again shortly,
     or contact us if the problem persists.
 
 # How long the iframe has to fire `load` before we swap to fallback.

--- a/_includes/script-selector-embed.html
+++ b/_includes/script-selector-embed.html
@@ -2,10 +2,6 @@
 
 {%- if ss.available -%}
   <div class="script-selector">
-    <div class="script-selector__banner" role="note">
-      {{ ss.banner }}
-    </div>
-
     <div class="script-selector__frame-wrap"
          data-fallback-heading="{{ ss.fallback.heading }}"
          data-fallback-message="{{ ss.fallback.message }}"

--- a/_includes/script-selector-embed.html
+++ b/_includes/script-selector-embed.html
@@ -1,0 +1,84 @@
+{%- assign ss = site.data.script_selector -%}
+
+{%- if ss.available -%}
+  <div class="script-selector">
+    <div class="script-selector__banner" role="note">
+      {{ ss.banner }}
+    </div>
+
+    <div class="script-selector__frame-wrap"
+         data-fallback-heading="{{ ss.fallback.heading }}"
+         data-fallback-message="{{ ss.fallback.message }}"
+         data-fallback-url="{{ ss.url }}"
+         data-timeout-ms="{{ ss.timeout_seconds | times: 1000 }}">
+      <iframe
+        class="script-selector__frame"
+        src="{{ ss.url }}"
+        title="Script selector"
+        loading="lazy"
+        referrerpolicy="no-referrer-when-downgrade"
+        allow="downloads"></iframe>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var wrap = document.currentScript.previousElementSibling
+                   .querySelector('.script-selector__frame-wrap');
+      var frame = wrap.querySelector('iframe');
+      var timeoutMs = parseInt(wrap.dataset.timeoutMs, 10);
+
+      var fired = false;
+      var timer = setTimeout(showFallback, timeoutMs);
+      frame.addEventListener('load', function () {
+        fired = true;
+        clearTimeout(timer);
+      });
+
+      function showFallback() {
+        if (fired) return;
+
+        // Build fallback DOM with safe construction (no innerHTML / no
+        // string concatenation into HTML). Strings come from data-*
+        // attributes set from a developer-controlled YAML data file,
+        // but using textContent guards against future changes that
+        // might source any of these from less-controlled inputs.
+        var fallback = document.createElement('div');
+        fallback.className = 'script-selector__fallback';
+        fallback.setAttribute('role', 'status');
+
+        var heading = document.createElement('h2');
+        heading.textContent = wrap.dataset.fallbackHeading;
+        fallback.appendChild(heading);
+
+        var message = document.createElement('p');
+        message.textContent = wrap.dataset.fallbackMessage;
+        fallback.appendChild(message);
+
+        var linkPara = document.createElement('p');
+        var link = document.createElement('a');
+        link.href = wrap.dataset.fallbackUrl;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = 'Open the script selector in a new tab →';
+        linkPara.appendChild(link);
+        fallback.appendChild(linkPara);
+
+        wrap.replaceChildren(fallback);
+      }
+    })();
+  </script>
+
+{%- else -%}
+
+  <div class="script-selector__fallback" role="status">
+    <h2>{{ ss.fallback.heading }}</h2>
+    <p>{{ ss.fallback.message }}</p>
+    <p>
+      <a href="{{ ss.url }}" target="_blank" rel="noopener noreferrer">
+        Open the script selector in a new tab →
+      </a>
+    </p>
+  </div>
+
+{%- endif -%}

--- a/_pages/software/ready-made-scripts.md
+++ b/_pages/software/ready-made-scripts.md
@@ -53,7 +53,7 @@ X (Twitter)
 
 ## Tailor a script for your study
 
-If you need a subset of a platform's data — say, just Instagram likes and connections — the [script selector](/software/script-selector/) lets you pick which fields you want and packages them as a Python wheel for your study.
+If you need a subset of a platform's data — say, just Instagram likes and followers — the [script selector](/software/script-selector/) lets you pick which fields you want and packages them as a Python wheel for your study.
 
 ## Need a script we don't have?
 

--- a/_pages/software/ready-made-scripts.md
+++ b/_pages/software/ready-made-scripts.md
@@ -51,6 +51,10 @@ LinkedIn
 X (Twitter)
 : tweets, likes, followers
 
+## Tailor a script for your study
+
+If you need a subset of a platform's data — say, just Instagram likes and connections — the [script selector](/software/script-selector/) lets you pick which fields you want and packages them as a Python wheel for your study.
+
 ## Need a script we don't have?
 
 We can also adapt an existing script for your study or build a new one for a platform we don't yet cover. Email [DataDonation@uu.nl](mailto:DataDonation@uu.nl?subject=Custom%20script%20request) to discuss what you need.

--- a/_pages/software/ready-made-scripts.md
+++ b/_pages/software/ready-made-scripts.md
@@ -53,7 +53,7 @@ X (Twitter)
 
 ## Tailor a script for your study
 
-If you need a subset of a platform's data — say, just Instagram likes and followers — the [script selector](/software/script-selector/) lets you pick which fields you want and packages them as a Python wheel for your study.
+If you need a subset of a platform's data (say, just Instagram likes and followers), the [script selector](/software/script-selector/) lets you pick which fields you want and packages them as a Python wheel for your study.
 
 ## Need a script we don't have?
 

--- a/_pages/software/script-selector.md
+++ b/_pages/software/script-selector.md
@@ -1,0 +1,31 @@
+---
+layout: page
+classes: wide
+title: "Script selector"
+permalink: /software/script-selector/
+toc: false
+sidebar:
+  nav: "software"
+hero:
+  image: /assets/images/hub/social-ideas.svg
+  alt: "A person presenting a board of ideas with colorful notes and a lightbulb."
+contact:
+  lead: "Have a question about the script selector?"
+  intro: "We can help with:"
+  bullets:
+    - "Using the selector in your study"
+    - "Reporting bugs or unexpected behavior"
+    - "Adding support for a platform we don't yet cover"
+  email: DataDonation@uu.nl
+  subject: "Question about the D3I script selector"
+---
+
+Pick the data you need from a platform — for example, Instagram likes and connections — and the selector packages a tailored Python script for your study.
+
+{% include script-selector-embed.html %}
+
+## About the script you get
+
+The selector composes scripts from the same set of [ready-made platform scripts](/software/ready-made-scripts/), packaged into a single Python wheel for what you picked. Drop the wheel into your data donation study like any other script — extracted data stays on the participant's device until they consent to donate it.
+
+If your platform isn't supported yet, [email us](mailto:DataDonation@uu.nl?subject=Custom%20script%20request).

--- a/_pages/software/script-selector.md
+++ b/_pages/software/script-selector.md
@@ -20,7 +20,7 @@ contact:
   subject: "Question about the D3I script selector"
 ---
 
-Pick the data you need from a platform — for example, Instagram likes and connections — and the selector packages a tailored Python script for your study.
+Pick the data you need from a platform — for example, Instagram likes and followers — and the selector packages a tailored Python script for your study.
 
 {% include script-selector-embed.html %}
 

--- a/_pages/software/script-selector.md
+++ b/_pages/software/script-selector.md
@@ -6,26 +6,20 @@ permalink: /software/script-selector/
 toc: false
 sidebar:
   nav: "software"
-hero:
-  image: /assets/images/hub/social-ideas.svg
-  alt: "A person presenting a board of ideas with colorful notes and a lightbulb."
+postit:
+  eyebrow: "Preview"
+  title: "In active development"
+  body: "If the selector stops responding, try refreshing the page."
 contact:
   lead: "Have a question about the script selector?"
-  intro: "We can help with:"
-  bullets:
-    - "Using the selector in your study"
-    - "Reporting bugs or unexpected behavior"
-    - "Adding support for a platform we don't yet cover"
   email: DataDonation@uu.nl
   subject: "Question about the D3I script selector"
 ---
 
-Pick the data you need from a platform — for example, Instagram likes and followers — and the selector packages a tailored Python script for your study.
+Pick the data you need from a platform (for example, Instagram likes and followers), and the selector packages a tailored Python script for your study.
 
 {% include script-selector-embed.html %}
 
 ## About the script you get
 
-The selector composes scripts from the same set of [ready-made platform scripts](/software/ready-made-scripts/), packaged into a single Python wheel for what you picked. Drop the wheel into your data donation study like any other script — extracted data stays on the participant's device until they consent to donate it.
-
-If your platform isn't supported yet, [email us](mailto:DataDonation@uu.nl?subject=Custom%20script%20request).
+The selector composes scripts from the same set of [ready-made platform scripts](/software/ready-made-scripts/), packaged into a single Python wheel for what you picked. Drop the wheel into your data donation study like any other script. Extracted data stays on the participant's device until they consent to donate it.

--- a/_sass/_script-selector.scss
+++ b/_sass/_script-selector.scss
@@ -1,0 +1,82 @@
+// =====================================================================
+// Script selector embed
+// =====================================================================
+
+.script-selector {
+  margin: 2rem 0 3rem;
+}
+
+.script-selector__banner {
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background-color: rgba($accent-secondary, 0.1);
+  border-left: 4px solid $accent-secondary;
+  border-radius: 4px;
+  font-family: "Nunito", $sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: $text-color;
+}
+
+.script-selector__frame-wrap {
+  position: relative;
+  width: 100%;
+  // Fixed responsive height. Adjust here based on visual review.
+  height: 600px;
+
+  @media (min-width: $small) {
+    height: 700px;
+  }
+
+  @media (min-width: $medium) {
+    height: 800px;
+  }
+}
+
+.script-selector__frame {
+  width: 100%;
+  height: 100%;
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  background-color: #fff;
+}
+
+.script-selector__fallback {
+  padding: 2rem;
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  background-color: rgba($border-color, 0.15);
+  text-align: center;
+  font-family: "Nunito", $sans-serif;
+
+  h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: $text-color;
+  }
+
+  p {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: $text-color;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  a {
+    color: $accent-primary;
+    font-weight: 700;
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    transition: border-color 0.15s ease;
+
+    &:hover,
+    &:focus {
+      border-bottom-color: $accent-primary;
+    }
+  }
+}

--- a/_sass/_script-selector.scss
+++ b/_sass/_script-selector.scss
@@ -6,31 +6,17 @@
   margin: 2rem 0 3rem;
 }
 
-.script-selector__banner {
-  margin-bottom: 1rem;
-  padding: 0.75rem 1rem;
-  background-color: rgba($accent-secondary, 0.1);
-  border-left: 4px solid $accent-secondary;
-  border-radius: 4px;
-  font-family: "Nunito", $sans-serif;
-  font-size: 0.95rem;
-  line-height: 1.4;
-  color: $text-color;
-}
-
 .script-selector__frame-wrap {
   position: relative;
   width: 100%;
-  // Fixed responsive height. Adjust here based on visual review.
-  height: 600px;
-
-  @media (min-width: $small) {
-    height: 700px;
-  }
-
-  @media (min-width: $medium) {
-    height: 800px;
-  }
+  // Sized for typical desktop viewports. The embedded LiveView
+  // currently uses h-[calc(100dvh-10rem)], which makes its content
+  // grow with iframe size — so iframes larger than viewport just
+  // grow the inner content too. Inner scroll is therefore expected
+  // until the embedded app adopts postMessage-based height reporting.
+  height: 80vh;
+  min-height: 700px;
+  max-height: 1000px;
 }
 
 .script-selector__frame {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -19,3 +19,4 @@
 @import "postit";
 @import "contact-cta";
 @import "data-sections";
+@import "script-selector";


### PR DESCRIPTION
## Summary

- New page at `/software/script-selector/` embedding the colleague's selector (`https://sramtest.d3idatadonation.src.surf-hosted.nl/select`)
- Build-time `available` flag in `_data/script_selector.yml` for planned outages
- JS timeout safety net (8s) for unexpected outages during development
- "Open in new tab" fallback link for both unavailability paths
- Sidebar nav entry; cross-link from `ready-made-scripts.md`
- Post-it "Preview / In active development" notice in the page corner
- New page is intentionally NOT registered in the Sveltia CMS (per spec §9)

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-04-30-script-selector-embed-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-script-selector-embed.md`

## Known follow-ups (not blockers)

- Iframe inner scroll on the Choose-platform step is caused by the LiveView's `h-[calc(100dvh-10rem)]` under-counting its chrome by ~3rem. 

## Test plan

- [ ] `/software/script-selector/` loads with the iframe visible
- [ ] Post-it appears top-right with "Preview / In active development"
- [ ] Sidebar shows "Script selector" under Software, highlighted as current page
- [ ] `/software/ready-made-scripts/` shows the new "Tailor a script for your study" section
- [ ] Setting `available: false` in the data file renders the fallback DOM
- [ ] Iframe failure (e.g. unreachable URL) renders the fallback via JS timeout
- [ ] Fallback "Open in new tab" link opens the selector URL

## Post-merge

After this lands on `main`, sync `cms-staging` per `cms/maintainer-notes.md`:

​`git push -f origin main:cms-staging`