### PR TITLE
Team page: filterable tag system

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,21 +35,6 @@ include:
 contact_email: DataDonation@uu.nl
 contact_subject: "Question about D3I"
 
-# Team member group ordering
-team_groups:
-  - key: lead
-    label: "Lead researchers"
-  - key: engineer
-    label: "Research engineers"
-  - key: methodologist
-    label: "Methodologists"
-  - key: legal
-    label: "Legal scholars"
-  - key: affiliated
-    label: "Affiliated researchers"
-  - key: alumni
-    label: "Alumni"
-
 # Collections
 collections:
   symposia:

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,81 +1,81 @@
 members:
   - name: Dr. L. (Laura) Boeschoten
     role: Project Lead D3I and Task Lead SSHOC-NL
-    group: lead
+    tags: [lead]
     image: /assets/images/people/laura.jpg
     url: https://www.uu.nl/medewerkers/LBoeschoten
   - name: Prof. Dr. T.B. (Theo) Araujo
     role: PI D3I and PI RIGHTS
-    group: lead
+    tags: [lead]
     image: /assets/images/people/theo.jpg
     url: https://www.uva.nl/profiel/a/r/t.b.araujo/t.b.araujo.html
   - name: Dr. N.C. (Niek) de Schipper
     role: Research Engineer, member of SoDa
-    group: engineer
+    tags: [engineer]
     image: /assets/images/people/niek.jpg
     url: https://www.uva.nl/en/profile/s/c/n.c.deschipper/n.c.de-schipper.html
   - name: Dr. M.B. (Max) Paulus
     role: Research Engineer
-    group: engineer
+    tags: [engineer]
     image: /assets/images/people/max.jpg
     url: https://www.uva.nl/profiel/p/a/m.paulus/m.paulus.html
   - name: Dr. D. (Danielle) McCool
     role: Research engineer and study design expert
-    group: engineer
+    tags: [engineer]
     image: /assets/images/people/danielle.jpg
     url: https://www.uu.nl/staff/DMMcCool
   - name: Dr. B. (Bella) Struminskaya
     role: Methodological expert
-    group: methodologist
+    tags: [methodologist]
     image: /assets/images/people/bella.jpg
     url: https://www.uu.nl/staff/BStruminskaya
-  - name: T.C. (Thijs) Carrière MSc.
-    role: PhD researcher
-    group: alumni
-    image: /assets/images/people/thijs.jpg
-    url: https://www.uu.nl/medewerkers/TCCarriere
   - name: Dr. mr. H.L. (Heleen) Janssen
     role: Legal expert
-    group: legal
+    tags: [legal]
     image: /assets/images/people/heleen.jpeg
     url: https://www.uva.nl/en/profile/j/a/h.l.janssen/h.l.janssen.html
   - name: Dr. J. (Jef) Ausloos
     role: Legal expert
-    group: legal
+    tags: [legal]
     image: /assets/images/people/jef.jpg
     url: https://www.uva.nl/profiel/a/u/j.ausloos/j.ausloos.html
   - name: Dr. K. (Kasper) Welbers
     role: VU Amsterdam affiliate
-    group: affiliated
+    tags: [affiliated]
     image: /assets/images/people/kasper.jpg
     url: https://research.vu.nl/en/persons/kasper-welbers
   - name: Dr. F. (Felicia) Loecherbach
     role: UvA affiliate and RIGHTS project lead
-    group: affiliated
+    tags: [affiliated]
     image: /assets/images/people/felicia.jpg
     url: https://www.uva.nl/profiel/l/o/f.loecherbach/f.loecherbach.html
   - name: Joshua Claassen MSc.
     role: Guest researcher from DZHW; Leibniz University Hannover
-    group: affiliated
+    tags: [affiliated]
     image: /assets/images/people/joshua.jpg
     url: https://www.dzhw.eu/en/gmbh/mitarbeiter?m_id=987
+  - name: Dachi Shanidze, MSc
+    role: Community Manager
+    tags: [community-manager]
+    image: /assets/images/people/9x12cm_72dpi_def_2024_aissr_dachi_edited.webp
+    url: https://www.uva.nl/en/profile/s/h/d.shanidze/d.shanidze.html
+  - name: Megan McEntee
+    role: Student Assistant
+    tags: [student-assistant]
+    image: /assets/images/people/megan.jpg
+    url: ''
+  - name: T.C. (Thijs) Carrière MSc.
+    role: PhD researcher
+    tags: [alumni]
+    image: /assets/images/people/thijs.jpg
+    url: https://www.uu.nl/medewerkers/TCCarriere
   - name: J. (Jonathan) Koop BSc.
     role: Research assistant
-    group: alumni
+    tags: [alumni]
     image: /assets/images/people/jonathan.jpg
     url: ''
   - name: P. (Pavlos) Ferlachidis MSc.
     role: Research assistant
-    group: alumni
+    tags: [alumni]
     image: /assets/images/people/pavlos.jpg
     url: ''
-  - name: Megan McEntee
-    role: Student Assistant
-    group: methodologist
-    image: /assets/images/people/megan.jpg
-    url: ''
-  - name: Dachi Shanidze, MSc
-    role: Community Manager
-    group: affiliated
-    image: /assets/images/people/9x12cm_72dpi_def_2024_aissr_dachi_edited.webp
-    url: https://www.uva.nl/en/profile/s/h/d.shanidze/d.shanidze.html

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,81 +1,65 @@
 members:
   - name: Dr. L. (Laura) Boeschoten
-    role: Project Lead D3I and Task Lead SSHOC-NL
-    tags: [lead]
+    tags: [Lead researcher, D3I, SSHOC-NL]
     image: /assets/images/people/laura.jpg
     url: https://www.uu.nl/medewerkers/LBoeschoten
   - name: Prof. Dr. T.B. (Theo) Araujo
-    role: PI D3I and PI RIGHTS
-    tags: [lead]
+    tags: [Lead researcher, D3I, RIGHTS]
     image: /assets/images/people/theo.jpg
     url: https://www.uva.nl/profiel/a/r/t.b.araujo/t.b.araujo.html
   - name: Dr. N.C. (Niek) de Schipper
-    role: Research Engineer, member of SoDa
-    tags: [engineer]
+    tags: [Research engineer, SoDa]
     image: /assets/images/people/niek.jpg
     url: https://www.uva.nl/en/profile/s/c/n.c.deschipper/n.c.de-schipper.html
   - name: Dr. M.B. (Max) Paulus
-    role: Research Engineer
-    tags: [engineer]
+    tags: [Research engineer]
     image: /assets/images/people/max.jpg
     url: https://www.uva.nl/profiel/p/a/m.paulus/m.paulus.html
   - name: Dr. D. (Danielle) McCool
-    role: Research engineer and study design expert
-    tags: [engineer]
+    tags: [Research engineer, Methodologist]
     image: /assets/images/people/danielle.jpg
     url: https://www.uu.nl/staff/DMMcCool
   - name: Dr. B. (Bella) Struminskaya
-    role: Methodological expert
-    tags: [methodologist]
+    tags: [Methodologist]
     image: /assets/images/people/bella.jpg
     url: https://www.uu.nl/staff/BStruminskaya
   - name: Dr. mr. H.L. (Heleen) Janssen
-    role: Legal expert
-    tags: [legal]
+    tags: [Legal scholar, RIGHTS]
     image: /assets/images/people/heleen.jpeg
     url: https://www.uva.nl/en/profile/j/a/h.l.janssen/h.l.janssen.html
   - name: Dr. J. (Jef) Ausloos
-    role: Legal expert
-    tags: [legal]
+    tags: [Legal scholar]
     image: /assets/images/people/jef.jpg
     url: https://www.uva.nl/profiel/a/u/j.ausloos/j.ausloos.html
   - name: Dr. K. (Kasper) Welbers
-    role: VU Amsterdam affiliate
-    tags: [affiliated]
+    tags: [Affiliated researcher]
     image: /assets/images/people/kasper.jpg
     url: https://research.vu.nl/en/persons/kasper-welbers
   - name: Dr. F. (Felicia) Loecherbach
-    role: UvA affiliate and RIGHTS project lead
-    tags: [affiliated]
+    tags: [Affiliated researcher, RIGHTS]
     image: /assets/images/people/felicia.jpg
     url: https://www.uva.nl/profiel/l/o/f.loecherbach/f.loecherbach.html
   - name: Joshua Claassen MSc.
-    role: Guest researcher from DZHW; Leibniz University Hannover
-    tags: [affiliated]
+    tags: [Guest researcher]
     image: /assets/images/people/joshua.jpg
     url: https://www.dzhw.eu/en/gmbh/mitarbeiter?m_id=987
   - name: Dachi Shanidze, MSc
-    role: Community Manager
-    tags: [community-manager]
+    tags: [Community manager]
     image: /assets/images/people/9x12cm_72dpi_def_2024_aissr_dachi_edited.webp
     url: https://www.uva.nl/en/profile/s/h/d.shanidze/d.shanidze.html
   - name: Megan McEntee
-    role: Student Assistant
-    tags: [student-assistant]
+    tags: [Student assistant]
     image: /assets/images/people/megan.jpg
     url: ''
   - name: T.C. (Thijs) Carrière MSc.
-    role: PhD researcher
-    tags: [alumni]
+    tags: [Alumnus, PhD researcher]
     image: /assets/images/people/thijs.jpg
     url: https://www.uu.nl/medewerkers/TCCarriere
   - name: J. (Jonathan) Koop BSc.
-    role: Research assistant
-    tags: [alumni]
+    tags: [Alumnus, Student assistant]
     image: /assets/images/people/jonathan.jpg
     url: ''
   - name: P. (Pavlos) Ferlachidis MSc.
-    role: Research assistant
-    tags: [alumni]
+    tags: [Alumnus, Research assistant]
     image: /assets/images/people/pavlos.jpg
     url: ''

--- a/_data/team_tags.yml
+++ b/_data/team_tags.yml
@@ -1,12 +1,21 @@
 # Controlled vocabulary for Team page tags. Order here = chip display order
-# on /about-d3i/team. Each member in _data/team.yml references tags by slug.
+# on /about-d3i/team. The manager edits only the display label; the internal
+# slug used for filtering/CSS is derived automatically at build time
+# (Liquid `slugify`). Members in _data/team.yml reference tags by label.
 # Editable in the CMS under About D3I -> Team -> "Team tags".
 tags:
-  - { slug: lead,              label: "Lead researchers" }
-  - { slug: engineer,          label: "Research engineers" }
-  - { slug: methodologist,     label: "Methodologists" }
-  - { slug: legal,             label: "Legal scholars" }
-  - { slug: affiliated,        label: "Affiliated researchers" }
-  - { slug: community-manager, label: "Community manager" }
-  - { slug: student-assistant, label: "Student assistant" }
-  - { slug: alumni,            label: "Alumni" }
+  - { label: "Lead researcher" }
+  - { label: "Research engineer" }
+  - { label: "Methodologist" }
+  - { label: "Legal scholar" }
+  - { label: "Affiliated researcher" }
+  - { label: "Guest researcher" }
+  - { label: "Community manager" }
+  - { label: "Student assistant" }
+  - { label: "Research assistant" }
+  - { label: "PhD researcher" }
+  - { label: "Alumnus" }
+  - { label: "D3I" }
+  - { label: "SSHOC-NL" }
+  - { label: "RIGHTS" }
+  - { label: "SoDa" }

--- a/_data/team_tags.yml
+++ b/_data/team_tags.yml
@@ -1,0 +1,12 @@
+# Controlled vocabulary for Team page tags. Order here = chip display order
+# on /about-d3i/team. Each member in _data/team.yml references tags by slug.
+# Editable in the CMS under About D3I -> Team -> "Team tags".
+tags:
+  - { slug: lead,              label: "Lead researchers" }
+  - { slug: engineer,          label: "Research engineers" }
+  - { slug: methodologist,     label: "Methodologists" }
+  - { slug: legal,             label: "Legal scholars" }
+  - { slug: affiliated,        label: "Affiliated researchers" }
+  - { slug: community-manager, label: "Community manager" }
+  - { slug: student-assistant, label: "Student assistant" }
+  - { slug: alumni,            label: "Alumni" }

--- a/_includes/data-sections/people-grid.html
+++ b/_includes/data-sections/people-grid.html
@@ -3,34 +3,38 @@
 
 <div class="people-grid-wrap" data-people-grid>
 
-  {%- comment -%} Filter bar: hidden by CSS until the inline JS adds .is-ready {%- endcomment -%}
-  <div class="people-grid__filters" role="group" aria-label="Filter team members by role">
+  {%- comment -%} Filter bar: hidden by CSS until the inline JS adds .is-ready.
+  Slugs are derived from labels at build time (slugify); the data stores labels. {%- endcomment -%}
+  <div class="people-grid__filters" role="group" aria-label="Filter team members by tag">
     <button type="button" class="people-grid__chip is-active" data-filter="*" aria-pressed="true">All</button>
     {%- for tag in vocab -%}
-      {%- assign tagged = members | where_exp: "m", "m.tags contains tag.slug" -%}
+      {%- assign tagged = members | where_exp: "m", "m.tags contains tag.label" -%}
       {%- if tagged.size > 0 -%}
-        <button type="button" class="people-grid__chip" data-filter="{{ tag.slug }}" aria-pressed="false">{{ tag.label }}</button>
+        {%- assign slug = tag.label | slugify -%}
+        <button type="button" class="people-grid__chip" data-filter="{{ slug }}" aria-pressed="false">{{ tag.label }}</button>
       {%- endif -%}
     {%- endfor -%}
   </div>
 
   <div class="people-grid">
     {%- for person in members -%}
-      <div class="people-grid__card" data-tags="{{ person.tags | join: ' ' }}">
+      {%- assign tagslugs = "" -%}
+      {%- for t in person.tags -%}
+        {%- assign s = t | slugify -%}
+        {%- assign tagslugs = tagslugs | append: ' ' | append: s -%}
+      {%- endfor -%}
+      <div class="people-grid__card" data-tags="{{ tagslugs | strip }}">
         {%- if person.image -%}
           <img class="people-grid__photo" src="{{ person.image | relative_url }}" alt="{{ person.name }}">
         {%- endif -%}
         <h3 class="people-grid__name">
           {%- if person.url -%}<a href="{{ person.url }}">{{ person.name }}</a>{%- else -%}{{ person.name }}{%- endif -%}
         </h3>
-        {%- if person.role -%}<p class="people-grid__role">{{ person.role }}</p>{%- endif -%}
         {%- if person.tags.size > 0 -%}
           <ul class="people-grid__tags">
-            {%- for slug in person.tags -%}
-              {%- assign tag = vocab | where: "slug", slug | first -%}
-              {%- if tag -%}
-                <li><span class="people-grid__tag" data-filter="{{ tag.slug }}">{{ tag.label }}</span></li>
-              {%- endif -%}
+            {%- for t in person.tags -%}
+              {%- assign s = t | slugify -%}
+              <li><span class="people-grid__tag" data-filter="{{ s }}">{{ t }}</span></li>
             {%- endfor -%}
           </ul>
         {%- endif -%}

--- a/_includes/data-sections/people-grid.html
+++ b/_includes/data-sections/people-grid.html
@@ -1,22 +1,73 @@
-{% assign items = site.data[include.data].members %}
-{% for group in site.team_groups %}
-  {% assign members = items | where: "group", group.key %}
-  {% if members.size > 0 %}
-    <h2 class="people-grid__heading">{{ group.label }}</h2>
-    <div class="people-grid">
-      {% for person in members %}
-        <div class="people-grid__card">
-          {% if person.image %}
-            <img class="people-grid__photo" src="{{ person.image | relative_url }}" alt="{{ person.name }}">
-          {% endif %}
-          <h3 class="people-grid__name">
-            {% if person.url %}<a href="{{ person.url }}">{{ person.name }}</a>{% else %}{{ person.name }}{% endif %}
-          </h3>
-          {% if person.role %}
-            <p class="people-grid__role">{{ person.role }}</p>
-          {% endif %}
-        </div>
-      {% endfor %}
-    </div>
-  {% endif %}
-{% endfor %}
+{%- assign members = site.data[include.data].members -%}
+{%- assign vocab = site.data.team_tags.tags -%}
+
+<div class="people-grid-wrap" data-people-grid>
+
+  {%- comment -%} Filter bar: hidden by CSS until the inline JS adds .is-ready {%- endcomment -%}
+  <div class="people-grid__filters" role="group" aria-label="Filter team members by role">
+    <button type="button" class="people-grid__chip is-active" data-filter="*" aria-pressed="true">All</button>
+    {%- for tag in vocab -%}
+      {%- assign tagged = members | where_exp: "m", "m.tags contains tag.slug" -%}
+      {%- if tagged.size > 0 -%}
+        <button type="button" class="people-grid__chip" data-filter="{{ tag.slug }}" aria-pressed="false">{{ tag.label }}</button>
+      {%- endif -%}
+    {%- endfor -%}
+  </div>
+
+  <div class="people-grid">
+    {%- for person in members -%}
+      <div class="people-grid__card" data-tags="{{ person.tags | join: ' ' }}">
+        {%- if person.image -%}
+          <img class="people-grid__photo" src="{{ person.image | relative_url }}" alt="{{ person.name }}">
+        {%- endif -%}
+        <h3 class="people-grid__name">
+          {%- if person.url -%}<a href="{{ person.url }}">{{ person.name }}</a>{%- else -%}{{ person.name }}{%- endif -%}
+        </h3>
+        {%- if person.role -%}<p class="people-grid__role">{{ person.role }}</p>{%- endif -%}
+        {%- if person.tags.size > 0 -%}
+          <ul class="people-grid__tags">
+            {%- for slug in person.tags -%}
+              {%- assign tag = vocab | where: "slug", slug | first -%}
+              {%- if tag -%}
+                <li><span class="people-grid__tag" data-filter="{{ tag.slug }}">{{ tag.label }}</span></li>
+              {%- endif -%}
+            {%- endfor -%}
+          </ul>
+        {%- endif -%}
+      </div>
+    {%- endfor -%}
+  </div>
+</div>
+
+<script>
+  (function () {
+    var root = document.currentScript.previousElementSibling;
+    var filters = root.querySelector('.people-grid__filters');
+    var chips = root.querySelectorAll('.people-grid__chip');
+    var cards = root.querySelectorAll('.people-grid__card');
+
+    // Progressive enhancement: reveal the filter bar only now that JS runs.
+    if (filters) { filters.classList.add('is-ready'); }
+
+    function apply(slug) {
+      cards.forEach(function (card) {
+        var tags = (card.getAttribute('data-tags') || '').split(' ');
+        var show = slug === '*' || tags.indexOf(slug) !== -1;
+        card.classList.toggle('people-grid__card--hidden', !show);
+      });
+      chips.forEach(function (chip) {
+        var active = chip.getAttribute('data-filter') === slug;
+        chip.classList.toggle('is-active', active);
+        chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    }
+
+    // One delegated handler serves both filter chips (<button>) and
+    // in-card pills (<span>); both carry data-filter.
+    root.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-filter]');
+      if (!btn || !root.contains(btn)) { return; }
+      apply(btn.getAttribute('data-filter'));
+    });
+  })();
+</script>

--- a/_sass/_data-sections.scss
+++ b/_sass/_data-sections.scss
@@ -32,18 +32,6 @@
   }
 }
 
-.people-grid__heading {
-  max-width: $content-width;
-  margin: 2rem 0 0;
-  font-family: "Nunito", $sans-serif;
-  font-size: 1.25rem;
-  font-weight: 800;
-  line-height: 1.2;
-  color: #252a34;
-  padding-bottom: 0.6rem;
-  border-bottom: 1px solid rgba(37, 42, 52, 0.08);
-}
-
 .people-grid__card {
   padding: 1.1rem 0.9rem;
   border-radius: 0.85rem;
@@ -95,6 +83,78 @@
   font-size: 0.8125rem;
   line-height: 1.4;
   color: $muted-text-color;
+}
+
+// People grid — filter bar, chips, card tag pills (tag system)
+
+.people-grid__filters {
+  display: none; // shown only when JS adds .is-ready (progressive enhancement)
+  max-width: $content-width;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1rem 0 0;
+
+  &.is-ready {
+    display: flex;
+  }
+}
+
+.people-grid__chip {
+  font-family: "Nunito", $sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid rgba(37, 42, 52, 0.15);
+  border-radius: 999px;
+  background: #fff;
+  color: #252a34;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+  &:hover,
+  &:focus {
+    border-color: $accent-primary;
+    color: $accent-primary;
+  }
+
+  &.is-active {
+    background: $accent-primary;
+    border-color: $accent-primary;
+    color: #fff;
+  }
+}
+
+.people-grid__card--hidden {
+  display: none;
+}
+
+.people-grid__tags {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.3rem;
+}
+
+.people-grid__tag {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: #f0f2f5;
+  color: $muted-text-color;
+  cursor: pointer; // mouse-click filters; not keyboard-focusable by design
+  transition: background-color 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    background: $accent-primary;
+    color: #fff;
+  }
 }
 
 // ---------------------------------------------------------------------

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -99,7 +99,7 @@ collections:
         label: "Team members"
         icon: people
         format: yml
-        description: "People listed on the Team page, grouped by role."
+        description: "People listed on the Team page, tagged by role."
         fields:
           - name: members
             label: "Members"
@@ -109,16 +109,17 @@ collections:
             fields:
               - { name: name, label: "Name", widget: string }
               - { name: role, label: "Role / title", widget: string }
-              - name: group
-                label: "Group"
-                widget: select
-                options:
-                  - { label: "Lead researchers", value: lead }
-                  - { label: "Research engineers", value: engineer }
-                  - { label: "Methodologists", value: methodologist }
-                  - { label: "Legal scholars", value: legal }
-                  - { label: "Affiliated researchers", value: affiliated }
-                  - { label: "Alumni", value: alumni }
+              - name: tags
+                label: "Tags"
+                widget: relation
+                collection: about_d3i
+                file: team_tags
+                value_field: "{{tags.*.slug}}"
+                display_fields: ["{{tags.*.label}}"]
+                search_fields: ["{{tags.*.label}}"]
+                multiple: true
+                required: false
+                hint: "One or more roles. These drive the filter chips on the Team page. To add a new tag, edit 'Team tags' first."
               - name: image
                 label: "Photo"
                 widget: image
@@ -128,6 +129,22 @@ collections:
                 max_file_size: 2097152
                 accept: "image/jpeg,image/png,image/svg+xml,image/webp"
               - { name: url, label: "Profile URL", widget: string, required: false }
+
+      - file: _data/team_tags.yml
+        name: team_tags
+        label: "Team tags"
+        icon: label
+        format: yml
+        description: "The tag vocabulary for the Team page (the filter chips). Add a tag here, then assign it to people in Team members."
+        fields:
+          - name: tags
+            label: "Tags"
+            label_singular: "Tag"
+            widget: list
+            summary: "{{label}}"
+            fields:
+              - { name: label, label: "Display label", widget: string, hint: "Shown as the filter chip and the badge on each card." }
+              - { name: slug, label: "Slug (internal id)", widget: string, pattern: ['^[a-z0-9-]+$', "Lowercase letters, numbers and hyphens only"], hint: "Stable internal id, e.g. student-assistant. Do not change it once people use it." }
 
       - { divider: true, label: "Advisory board" }
       - file: _pages/about-d3i/advisory-board.md

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -105,21 +105,20 @@ collections:
             label: "Members"
             label_singular: "Member"
             widget: list
-            summary: "{{name}} — {{role}}"
+            summary: "{{name}}"
             fields:
               - { name: name, label: "Name", widget: string }
-              - { name: role, label: "Role / title", widget: string }
               - name: tags
                 label: "Tags"
                 widget: relation
                 collection: about_d3i
                 file: team_tags
-                value_field: "{{tags.*.slug}}"
+                value_field: "{{tags.*.label}}"
                 display_fields: ["{{tags.*.label}}"]
                 search_fields: ["{{tags.*.label}}"]
                 multiple: true
                 required: false
-                hint: "One or more roles. These drive the filter chips on the Team page. To add a new tag, edit 'Team tags' first."
+                hint: "This person's roles, projects, and affiliations. These drive the filter chips on the Team page. To add a new tag, edit 'Team tags' first."
               - name: image
                 label: "Photo"
                 widget: image
@@ -135,7 +134,7 @@ collections:
         label: "Team tags"
         icon: label
         format: yml
-        description: "The tag vocabulary for the Team page (the filter chips). Add a tag here, then assign it to people in Team members."
+        description: "The tag vocabulary for the Team page (the filter chips). Add a tag here, then assign it to people in Team members. Order = chip order on the page."
         fields:
           - name: tags
             label: "Tags"
@@ -143,8 +142,7 @@ collections:
             widget: list
             summary: "{{label}}"
             fields:
-              - { name: label, label: "Display label", widget: string, hint: "Shown as the filter chip and the badge on each card." }
-              - { name: slug, label: "Slug (internal id)", widget: string, pattern: ['^[a-z0-9-]+$', "Lowercase letters, numbers and hyphens only"], hint: "Stable internal id, e.g. student-assistant. Do not change it once people use it." }
+              - { name: label, label: "Display label", widget: string, hint: "Shown as the filter chip and the badge on each card. The internal id used for filtering is generated automatically." }
 
       - { divider: true, label: "Advisory board" }
       - file: _pages/about-d3i/advisory-board.md


### PR DESCRIPTION
## Summary
- Replace the grouped section headers on /about-d3i/team with one filterable grid (tag chips + inline vanilla JS; no-JS fallback shows the full grid).
- Tag vocabulary moves from _config.yml `team_groups` into CMS-editable `_data/team_tags.yml`; members carry multiple tags.
- Retire the `role`/title field — role, project, and affiliation info is now represented entirely as tags (D3I, SSHOC-NL, RIGHTS, SoDa, etc.); cards show name + tag pills.
- Label-only model: the manager edits display labels only; the filter slug is derived at build time via Liquid `slugify`.

## Test plan
- [x] `bundle exec jekyll build` clean; rendered team page has 0 headings, 16 cards, all 15 chips.
- [x ] Browser: chips filter, "All" resets, pill click filters, no-JS shows full grid with hidden filter bar.
- [ ] CMS smoke test: the "Tags" relation widget populates from "Team tags" and stores labels; adding a tag in "Team tags" makes it selectable on a person.

