### PR TITLE
feat(news): CMS-managed news with homepage strip and Atom feeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :jekyll_plugins do
   gem "jekyll-redirect-from"
   gem "jekyll-sitemap", "~> 1.4"
   gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-feed", "~> 0.17"
 end
 
 gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
@@ -90,6 +92,7 @@ PLATFORMS
 DEPENDENCIES
   erb (~> 6.0)
   jekyll (~> 4.3)
+  jekyll-feed (~> 0.17)
   jekyll-redirect-from
   jekyll-seo-tag (~> 2.8)
   jekyll-sitemap (~> 1.4)

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-seo-tag
+  - jekyll-feed
 
 sass:
   style: compressed
@@ -40,9 +41,19 @@ collections:
   events:
     output: true
     permalink: /community/events/:path/
+  news:
+    output: true
+    permalink: /news/:path/
 
 # Publish collection documents dated in the future (e.g. upcoming events)
 future: true
+
+# Atom feeds (jekyll-feed): /feed/news.xml and /feed/events.xml, for
+# external aggregators (e.g. ODISSEI) to ingest our items.
+feed:
+  collections:
+    - news
+    - events
 
 # Custom URLs
 # newsletter_signup_url and phd_network_signup_url were retired when their

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -34,6 +34,8 @@ main:
     url: /software/
   - title: "Community & Events"
     url: /community/
+  - title: "News"
+    url: /news/
   - title: "About D3I"
     url: /about-d3i/
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% seo %}
+{% feed_meta %}
+<link type="application/atom+xml" rel="alternate" href="{{ '/feed/news.xml' | absolute_url }}" title="{{ site.title }} | News" />
+<link type="application/atom+xml" rel="alternate" href="{{ '/feed/events.xml' | absolute_url }}" title="{{ site.title }} | Events" />
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 {% include head/custom.html %}

--- a/_includes/news-card.html
+++ b/_includes/news-card.html
@@ -1,0 +1,32 @@
+{% assign item = include.item %}
+
+{% comment %}
+  News cards prefer external_url over the item's own page — deliberately
+  the reverse of archive-card.html, because an external-only news item has
+  no meaningful local page (its body is typically empty).
+{% endcomment %}
+{% if item.external_url %}
+  {% assign card_href = item.external_url %}
+  {% assign card_external = true %}
+{% else %}
+  {% assign card_href = item.url | relative_url %}
+  {% assign card_external = false %}
+{% endif %}
+
+<article class="news-card" data-news-date="{{ item.date | date: '%Y-%m-%d' }}">
+  {% if item.image %}
+    <a class="news-card__media" href="{{ card_href }}"{% if card_external %} target="_blank" rel="noopener noreferrer"{% endif %} tabindex="-1" aria-hidden="true">
+      <img src="{{ item.image | relative_url }}" alt="{{ item.image_alt | default: '' }}" loading="lazy">
+    </a>
+  {% endif %}
+  <div class="news-card__body">
+    <h3 class="news-card__title">
+      <a href="{{ card_href }}"{% if card_external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ item.title }}</a>
+    </h3>
+    <p class="news-card__date">{{ item.date | date: "%B %-d, %Y" }}</p>
+    {% if item.summary %}
+      <p class="news-card__summary">{{ item.summary }}</p>
+    {% endif %}
+    <a class="cta-link news-card__link" href="{{ card_href }}"{% if card_external %} target="_blank" rel="noopener noreferrer"{% endif %}>Read more <span aria-hidden="true">→</span></a>
+  </div>
+</article>

--- a/_includes/news-strip.html
+++ b/_includes/news-strip.html
@@ -1,0 +1,32 @@
+{% comment %}
+  Homepage "Latest news" strip: up to 3 news items no older than 90 days.
+  The same window is re-applied at view time by news-freshness.js, because
+  Liquid only sees the build date and production deploys can be months
+  apart — without the JS, stale items would linger until the next build.
+{% endcomment %}
+
+{% assign now_epoch = site.time | date: "%s" | plus: 0 %}
+{% assign freshness_cutoff = now_epoch | minus: 7776000 %}
+{% assign sorted_news = site.news | sort: "date" | reverse %}
+{% assign recent_news = "" | split: "" %}
+{% for item in sorted_news %}
+  {% assign item_epoch = item.date | date: "%s" | plus: 0 %}
+  {% if item_epoch >= freshness_cutoff and recent_news.size < 3 %}
+    {% assign recent_news = recent_news | push: item %}
+  {% endif %}
+{% endfor %}
+
+{% if recent_news.size > 0 %}
+  <section class="home-news" data-news-strip>
+    <div class="home-news__header">
+      <h2 class="home-news__title">Latest news</h2>
+      <a class="cta-link" href="{{ '/news/' | relative_url }}">More news <span aria-hidden="true">→</span></a>
+    </div>
+    <div class="news-grid">
+      {% for item in recent_news %}
+        {% include news-card.html item=item %}
+      {% endfor %}
+    </div>
+  </section>
+  <script src="{{ '/assets/js/news-freshness.js' | relative_url }}" defer></script>
+{% endif %}

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -30,3 +30,5 @@ layout: site-shell
 
   {{ content }}
 </article>
+
+{% include news-strip.html %}

--- a/_layouts/page-news.html
+++ b/_layouts/page-news.html
@@ -1,0 +1,34 @@
+---
+layout: site-shell
+---
+
+{% assign news_items = site.news | sort: "date" | reverse %}
+{% assign stripped_content = content | strip %}
+
+<article class="content-page">
+  <div class="content-page__grid content-page__grid--full">
+    <div class="content-page__main">
+      {% include content-page-intro.html %}
+
+      <div class="news-page">
+        {% if stripped_content != '' %}
+          <div class="news-page__intro">
+            <div class="prose">
+              {{ content }}
+            </div>
+          </div>
+        {% endif %}
+
+        {% if news_items.size > 0 %}
+          <div class="news-grid">
+            {% for item in news_items %}
+              {% include news-card.html item=item %}
+            {% endfor %}
+          </div>
+        {% endif %}
+      </div>
+
+      {% include contact-cta.html constrained=true %}
+    </div>
+  </div>
+</article>

--- a/_pages/news/index.md
+++ b/_pages/news/index.md
@@ -1,0 +1,16 @@
+---
+layout: page-news
+title: News
+permalink: /news/
+excerpt: "News and announcements from the D3I project and the wider data donation community."
+contact:
+  lead: "Have news to share?"
+  intro: "Get in touch:"
+  bullets:
+    - Announcements or milestones from your data donation project
+    - News items to feature on this page
+  email: DataDonation@uu.nl
+  subject: "News item for datadonation.eu"
+---
+
+News and announcements from the D3I project and the wider data donation community. Looking for upcoming symposia, courses, and workshops? See our [events](/community/events/).

--- a/_sass/_news.scss
+++ b/_sass/_news.scss
@@ -1,0 +1,99 @@
+// =====================================================================
+// News: cards (shared by /news/ and the homepage strip), the news page
+// grid, and the homepage "Latest news" strip
+// =====================================================================
+
+.news-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+
+  @media (min-width: $medium) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.news-card {
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border: 1px solid rgba(37, 42, 52, 0.1);
+  border-radius: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+  overflow: hidden;
+}
+
+.news-card__media {
+  display: block;
+  aspect-ratio: 16 / 9;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.news-card__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 1.15rem 1.2rem;
+}
+
+.news-card__title {
+  margin: 0;
+  font-family: "Nunito", $sans-serif;
+  font-size: 1.15rem;
+  font-weight: 800;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover, &:focus {
+      color: $accent-primary;
+    }
+  }
+}
+
+.news-card__date {
+  margin: 0.35rem 0 0;
+  color: $muted-text-color;
+  font-size: 0.95rem;
+}
+
+.news-card__summary {
+  margin: 0.85rem 0 0;
+}
+
+.news-card__link {
+  margin-top: auto;
+  padding-top: 0.85rem;
+}
+
+.news-page__intro {
+  max-width: $content-width;
+  margin-bottom: 2rem;
+}
+
+.home-news {
+  max-width: $site-width;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+}
+
+.home-news__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.home-news__title {
+  margin: 0;
+  font-family: "Nunito", $sans-serif;
+  font-size: 1.6rem;
+  font-weight: 800;
+}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -729,6 +729,45 @@ collections:
       - { name: sidebar, widget: hidden, default: { nav: "community" } }
       - { name: body, label: "Full event page content (markdown)", widget: markdown }
 
+  # ──────────────── News (peer to Community — entry collection) ───────────
+  # Folder collection for news items. Each item appears on /news/ and,
+  # while fresh (under ~3 months old), in the homepage "Latest news" strip.
+  # The freshness window is enforced at build time AND client-side
+  # (assets/js/news-freshness.js), so old items drop off the homepage even
+  # when the site isn't rebuilt for months.
+  - name: news
+    label: "News"
+    icon: newspaper
+    folder: _news
+    create: true
+    extension: md
+    format: yaml-frontmatter
+    slug: "{{fields.date | date('YYYY-MM-DD')}}-{{slug}}"
+    summary: "{{title}} — {{date}}"
+    path: "{{fields.date | date('YYYY-MM-DD')}}-{{slug}}"
+    description: "News items shown on /news/ and, while fresh (under ~3 months old), in the homepage 'Latest news' strip. For a story that lives elsewhere (e.g. a partner site), fill in the External URL field — cards then link straight there and the body may stay empty. Add a new item with the '+' button."
+    fields:
+      - { name: title, label: "Title", widget: string }
+      - name: date
+        label: "Date"
+        widget: datetime
+        type: date
+        comment: "Publication date. Newest items appear first; items older than ~3 months drop off the homepage strip automatically (they stay on /news/)."
+      - { name: summary, label: "Short summary (used in cards)", widget: text }
+      - name: image
+        label: "Image (optional)"
+        widget: image
+        required: false
+        media_folder: /assets/images/news
+        public_folder: /assets/images/news
+        choose_url: false
+        max_file_size: 2097152
+        accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+      - { name: image_alt, label: "Image alt text", widget: string, required: false, comment: "Describe the image for screen readers. Fill in whenever an image is set." }
+      - { name: external_url, label: "External URL (optional)", widget: string, required: false, comment: "If the story lives elsewhere, put its URL here — cards link straight out and the body below may stay empty." }
+      - { name: layout, widget: hidden, default: "page" }
+      - { name: body, label: "Full news item content (markdown)", widget: markdown, required: false }
+
   # ──────────────────────── Prepare a Study ───────────────────────────────
   - name: prepare_a_study
     label: "Prepare a Study"

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -21,3 +21,4 @@
 @import "data-sections";
 @import "script-builder";
 @import "usage-figures";
+@import "news";

--- a/assets/js/news-freshness.js
+++ b/assets/js/news-freshness.js
@@ -1,0 +1,25 @@
+// Client-side freshness window for the homepage news strip. The strip is
+// rendered at build time with the same 90-day cutoff, but production
+// builds can be months apart, so the cutoff is re-applied here with the
+// visitor's clock: stale cards are removed, and the whole strip goes when
+// no cards remain.
+(function () {
+  var WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
+
+  function prune() {
+    var strip = document.querySelector("[data-news-strip]");
+    if (!strip) return;
+    var cutoff = Date.now() - WINDOW_MS;
+    strip.querySelectorAll("[data-news-date]").forEach(function (card) {
+      var published = Date.parse(card.getAttribute("data-news-date"));
+      if (!isNaN(published) && published < cutoff) card.remove();
+    });
+    if (!strip.querySelector("[data-news-date]")) strip.remove();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", prune);
+  } else {
+    prune();
+  }
+})();

--- a/cms/community-manager-guide.md
+++ b/cms/community-manager-guide.md
@@ -45,6 +45,7 @@ The sidebar groups everything you can edit by site section:
 - **About D3I** — page editors and data lists for `/about-d3i/` (Team, Advisory board, Funding, Partners, Impact and adoption).
 - **Community** — page editors and data lists for `/community/` (Networks, Newsletter, Courses).
 - **Events** — create new event pages (symposia, courses, workshops, and more); edit existing ones. Each entry produces its own page on the site and is listed on `/community/events/`; the Courses and Symposia pages automatically show the entries of the matching type.
+- **News** — create news items. Each item appears on `/news/` and, while fresh (under ~3 months old), in the homepage "Latest news" strip.
 - **Prepare a Study** — page editor and data list for the Completed projects page.
 - **Site Structure** — site-wide configuration (Navigation). Rarely needs editing.
 
@@ -75,6 +76,16 @@ This stores your edit on the `cms-staging` branch — it's saved, but not yet vi
 4. Fill in Title, Start date, End date, Location, Summary, optional External URL and details/actions. For an event people should register for, add an action button (e.g. "Register" pointing at the registration link).
 5. Write the full event page content in the **Full event page content** field. (For events whose primary page lives elsewhere, the External URL is enough — visitors land on this site's page first and can click through.)
 6. Click **Save**.
+
+### Add a news item
+
+1. Dashboard → News.
+2. Click **New News**.
+3. Fill in Title, Date, and Summary; optionally upload an Image (with alt text).
+4. Write the story in the body field — or, for news that lives elsewhere (e.g. an announcement on a partner site), fill in the **External URL** instead and leave the body empty; the news card then links straight there.
+5. Click **Save**.
+
+News items appear on the News page immediately after publication. The homepage "Latest news" strip shows the three most recent items and automatically drops anything older than about 3 months.
 
 ## How "Save" works
 


### PR DESCRIPTION
- new _news/ folder collection (output to /news/:path/); items support optional image and external-only links (cards link straight out)
- /news/ page (page-news layout + news-card include, ASCoR-style grid)
- homepage 'Latest news' strip: up to 3 items, 90-day window enforced at build time AND client-side (news-freshness.js) so stale items drop off even when production isn't rebuilt for months
- top-level News nav tab
- jekyll-feed: /feed/news.xml and /feed/events.xml with autodiscovery links in head, for external aggregators (e.g. ODISSEI) to ingest
- CMS: news collection (image upload to assets/images/news, WebP transform applies); community-manager guide section added