### PR TITLE
feat(cms): one-click publish workflow for CMS edits

### DIFF
--- a/.github/workflows/publish-cms-edits.yml
+++ b/.github/workflows/publish-cms-edits.yml
@@ -1,0 +1,88 @@
+name: Publish CMS edits
+
+# Manually triggered by an editor (Actions tab → "Publish CMS edits" →
+# Run workflow) once a batch of CMS edits on cms-staging is ready to go
+# live. Builds the site from cms-staging as a safety check, then
+# squash-merges cms-staging into main.
+#
+# Merges performed with GITHUB_TOKEN do not fire push-triggered
+# workflows, so the cms-staging reset and the staging deploy that would
+# normally react to the push to main are done explicitly at the end.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: "publish-cms-edits"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cms-staging
+        uses: actions/checkout@v4
+        with:
+          ref: cms-staging
+          fetch-depth: 0
+
+      - name: Check for unpublished edits
+        id: diff
+        run: |
+          git fetch origin main
+          if git diff --quiet origin/main...HEAD; then
+            echo "Nothing to publish — cms-staging has no changes on top of main." >> "$GITHUB_STEP_SUMMARY"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Ruby
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build with Jekyll (safety check)
+        if: steps.diff.outputs.has_changes == 'true'
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Squash-merge cms-staging into main
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --head cms-staging --base main --state open --json number --jq '.[0].number // empty')
+          if [ -z "$existing" ]; then
+            gh pr create --base main --head cms-staging \
+              --title "Publish CMS edits ($(date -u +%Y-%m-%d))" \
+              --body "Automated publication of CMS edits, triggered via the Publish CMS edits workflow by @${{ github.actor }}."
+          fi
+          gh pr merge cms-staging --squash
+
+      - name: Reset cms-staging to main
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          main_sha=$(gh api "repos/${REPO}/git/refs/heads/main" --jq .object.sha)
+          gh api -X PATCH "repos/${REPO}/git/refs/heads/cms-staging" \
+            -f sha="$main_sha" \
+            -F force=true
+
+      - name: Trigger staging deploy
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy-staging.yml --ref main
+          echo "CMS edits published to main; staging deploy started." >> "$GITHUB_STEP_SUMMARY"

--- a/cms/community-manager-guide.md
+++ b/cms/community-manager-guide.md
@@ -97,13 +97,11 @@ The CMS doesn't have a separate "Publish" button. To make your accumulated edits
 
 When you've finished a batch of edits and want them on the live site:
 
-1. Open https://github.com/d3i-website/d3i-website.github.io/compare/main...cms-staging in your browser.
-2. You'll see a list of every edit you (or anyone else editing the CMS) has made since the last publication. Scan it to confirm everything looks right.
-3. Click **Create pull request**. Add a brief title (e.g., "Update Team page and add March symposium") and click Create.
-4. On the new PR page, click **Squash and merge**. Confirm.
-5. Done. The site will rebuild automatically (1-2 min). The cumulative batch lands on `main` as a single clean commit.
+1. Open https://github.com/d3i-website/d3i-website.github.io/actions/workflows/publish-cms-edits.yml in your browser.
+2. Click **Run workflow** (green button, top right of the list), then **Run workflow** again to confirm.
+3. Done. The workflow test-builds the site with your edits, publishes them, and rebuilds the staging site (2-3 min in total). If the build fails, nothing is published — the run shows a red ✗; email Danielle with a link to it.
 
-If anything looks wrong in the diff, **don't merge** — email Danielle and describe what's off. She can help identify the issue or revert problem edits before publishing.
+Want to double-check what's going out first? Open https://github.com/d3i-website/d3i-website.github.io/compare/main...cms-staging to see every edit made since the last publication, then run the workflow when satisfied. If anything looks wrong in that diff, **don't publish** — email Danielle and describe what's off. She can help identify the issue or revert problem edits before publishing.
 
 After publishing, Danielle takes care of resetting `cms-staging` so the next session starts from a fresh baseline. If you ever come back and the compare view shows confusing "X commits ahead" with no real changes, that means the reset hasn't happened yet — email her to nudge.
 


### PR DESCRIPTION
Manually-dispatched 'Publish CMS edits' workflow: test-builds the site from cms-staging, squash-merges it into main, resets cms-staging, and dispatches the staging deploy (GITHUB_TOKEN merges don't fire push-triggered workflows, so the last two are explicit). No-ops cleanly when cms-staging has nothing on top of main.

Community-manager guide updated: publishing is now Run-workflow; the compare-view diff check stays documented as an optional step.