### PR TITLE
feat(cms): redesign admin around the manager's workflow

### DIFF
--- a/.github/workflows/publish-cms-edits.yml
+++ b/.github/workflows/publish-cms-edits.yml
@@ -1,9 +1,11 @@
 name: Publish CMS edits
 
-# Manually triggered by an editor (Actions tab → "Publish CMS edits" →
-# Run workflow) once a batch of CMS edits on cms-staging is ready to go
-# live. Builds the site from cms-staging as a safety check, then
-# squash-merges cms-staging into main.
+# Manually triggered by an editor — either the "Publish Changes" button
+# in the CMS header (which fires a repository_dispatch event of type
+# sveltia-cms-publish; see backend.skip_ci in admin/config.yml) or the
+# Actions tab (→ "Publish CMS edits" → Run workflow) — once a batch of
+# CMS edits on cms-staging is ready to go live. Builds the site from
+# cms-staging as a safety check, then squash-merges cms-staging into main.
 #
 # Merges performed with GITHUB_TOKEN do not fire push-triggered
 # workflows, so the cms-staging reset and the staging deploy that would
@@ -11,6 +13,8 @@ name: Publish CMS edits
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types: [sveltia-cms-publish]
 
 permissions:
   contents: write

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,6 +2,13 @@ backend:
   name: github
   repo: d3i-website/d3i-website.github.io
   branch: cms-staging
+  # skip_ci does two things for us: (1) it surfaces a "Publish Changes"
+  # button in the CMS header, which fires a `repository_dispatch` event
+  # (type: sveltia-cms-publish) that triggers the "Publish CMS edits"
+  # workflow — the manager's one-click publish; (2) it prefixes save
+  # commits with [skip ci], which is harmless here because nothing builds
+  # off cms-staging pushes anyway.
+  skip_ci: true
 
 # Manager-facing URLs point at staging, not production. The manager's
 # publication flow lands changes on staging via Pages rebuild (~2 min);
@@ -10,7 +17,9 @@ backend:
 # live site.
 site_url: https://d3i-website.github.io
 display_url: https://d3i-website.github.io
-logo_url: https://d3i-website.github.io/assets/images/favicon.svg
+app_title: "datadonation.eu admin"
+logo:
+  src: https://d3i-website.github.io/assets/images/favicon.svg
 
 media_folder: assets/images
 public_folder: /assets/images
@@ -32,19 +41,21 @@ media_libraries:
           optimize: true
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Collections — top-level entries mirror the site's IA (About D3I, Community,
-# etc.). Each section file collection holds the page editors AND the data
-# lists for that section, ordered by editor task flow (page first, then its
-# supporting data). Dividers inside each `files:` array group the
-# subsections (Team, Advisory board, etc.). Symposia stays as a peer entry
-# collection because it's editorially different (manager creates new
-# entries) — folder collections cannot nest inside file collections.
+# Collections — ordered around the manager's daily work: Events and News
+# first (the entry collections he creates content in), then — below a
+# divider — the site-section editors (Community, About D3I, Prepare a
+# Study), each holding that section's page editors AND its supporting data
+# lists, ordered by editor task flow (page first, then its data). Dividers
+# inside each `files:` array group the subsections.
 #
-# Sveltia limits: sidebar nesting is two levels (collection → file). The
-# `divider:` entries inside files: arrays are an experimental attempt to
-# get visual subsection grouping; if Sveltia ignores their `label:` they
-# still render as separators. If they fail entirely, dividers can be
-# stripped without affecting the schema.
+# Sveltia limits: sidebar nesting is two levels (collection → file), and
+# folder collections cannot nest inside file collections — which is why
+# Events and News sit at the top level rather than inside Community.
+#
+# Entry-list views: Events groups entries by year by default (mirroring
+# the year-folder organization the manager knows from Bloomreach) with
+# preset filters per event type; News sorts newest-first and shows image
+# thumbnails in grid view.
 #
 # Summary template syntax: list and object summaries use `{{fieldname}}`
 # (no `fields.` prefix). Slug/path templates use the `{{fields.X}}` form
@@ -52,356 +63,168 @@ media_libraries:
 # ─────────────────────────────────────────────────────────────────────────────
 collections:
 
-  # ──────────────────────── About D3I ─────────────────────────────────────
-  - name: about_d3i
-    label: "About D3I"
-    icon: account_balance
-    description: "Pages and data lists under About D3I (/about-d3i/)."
-    files:
-
-      - { divider: true, label: "Team" }
-      - file: _pages/about-d3i/team.md
-        name: team_page
-        label: "Team page"
-        icon: article
-        description: "The intro prose at /about-d3i/team. Team members themselves are edited in the next entry."
+  # ──────────────── Events (entry collection) ─────────────────────────────
+  # The deliberate decision: every event we acknowledge gets an `_events/`
+  # page (even if the body is bare and the page mostly links out via
+  # external_url). One collection, one rendering pattern, no separate
+  # "link-only" data file. The Courses and Symposia pages are typed views
+  # of this collection (archive.type in their frontmatter);
+  # /community/events/ shows everything.
+  - name: events
+    label: "Events"
+    icon: event
+    folder: _events
+    create: true
+    extension: md
+    format: yaml-frontmatter
+    slug: "{{fields.date | date('YYYY')}}-{{slug}}"
+    summary: "{{title}} — {{date | date('D MMM YYYY')}}"
+    thumbnail: false
+    sortable_fields:
+      fields: [date, title]
+      default:
+        field: date
+        direction: descending
+    # Group the entry list by year by default — the equivalent of the
+    # year folders in the Bloomreach Events tree.
+    view_groups:
+      groups:
+        - name: year
+          label: "Year"
+          field: date
+          pattern: '\d{4}'
+      default: year
+    # Preset filters per event type (the funnel icon above the entry list).
+    view_filters:
+      - { label: "Symposia", field: event_type, pattern: symposium }
+      - { label: "Courses", field: event_type, pattern: course }
+      - { label: "Workshops", field: event_type, pattern: workshop }
+      - { label: "Lectures", field: event_type, pattern: lecture }
+      - { label: "Other", field: event_type, pattern: other }
+    description: "Event pages for symposia, courses, workshops, and other events. Each entry produces its own page on this site. For events whose primary page lives elsewhere, fill in the External URL field — the manager can still write a brief frontmatter entry here so the event appears in the events archive. Add a new event with the '+' button."
+    fields:
+      - { name: title, label: "Title", widget: string }
+      - name: event_type
+        label: "Event type"
+        widget: select
+        options:
+          - { label: "Symposium", value: symposium }
+          - { label: "Course", value: course }
+          - { label: "Workshop", value: workshop }
+          - { label: "Lecture", value: lecture }
+          - { label: "Other", value: other }
+        comment: "Controls which archive pages list this event: the Courses page shows 'Course', the Symposia page shows 'Symposium', and every type appears on /community/events/."
+      - name: date
+        label: "Start date"
+        widget: datetime
+        type: date
+        comment: "Used to determine if the event is upcoming or past."
+      - name: end_date
+        label: "End date"
+        widget: datetime
+        type: date
+        required: false
+        comment: "Optional. If set, used for the upcoming/past decision instead of start date."
+      - name: date_label
+        label: "Date label (optional)"
+        widget: string
+        required: false
+        comment: "Optional display override for the date on cards, e.g. 'July 2025' when the exact day is unknown. The start date above still controls sorting and the upcoming/past split."
+      - { name: location, label: "Location", widget: string }
+      - { name: external_url, label: "External URL (event website)", widget: string, required: false, comment: "If the event's primary page lives elsewhere, put its URL here — cards link straight out." }
+      - { name: summary, label: "Short summary (used in cards)", widget: text }
+      - name: featured
+        label: "Spotlight this event?"
+        widget: boolean
+        required: false
+        default: false
+        comment: "Spotlights this event in the upcoming-event hero slot on the archive pages that list it. Only meaningful for upcoming events; past events ignore this flag (the layout uses dates to classify upcoming vs. past automatically)."
+      - name: postit
+        label: "Highlight (optional)"
+        widget: object
+        required: false
+        collapsed: true
+        summary: "{{title}}"
+        comment: "Optional time-sensitive highlight box rendered at the top of this event's page. Useful for things like 'Registration closes Friday' or 'Programme updated'. Leave the checkbox unchecked when not in use."
         fields:
-          - { name: title, label: "Page title", widget: string }
-          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
-          - name: body
-            label: "Intro prose (markdown)"
-            widget: markdown
-            hint: "Short prose shown above the team grid. Keep it brief — the grid itself is the main content."
-          - name: contact
-            label: "Contact CTA"
-            widget: object
-            collapsed: true
-            summary: "{{lead}}"
-            comment: "Renders as the contact CTA block at the bottom of the page."
-            fields:
-              - { name: lead, label: "Heading", widget: string }
-              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
-              - name: bullets
-                label: "Bullet points (optional)"
-                widget: list
-                required: false
-                field: { name: bullet, widget: string }
-              - { name: email, label: "Email address", widget: string, type: email }
-              - { name: subject, label: "Email subject", widget: string }
-          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
-          - { name: data_section, widget: hidden, default: { type: "people-grid", data: "team" } }
-          - { name: permalink, widget: hidden, default: "/about-d3i/team" }
-          - { name: layout, widget: hidden, default: "page" }
-          - { name: redirect_from, widget: hidden, default: ["/about-the-project/team", "/d3i/team"] }
-
-      - file: _data/team.yml
-        name: team_members
-        label: "Team members"
-        icon: people
-        format: yml
-        description: "People listed on the Team page, tagged by role."
+          - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+          - { name: title, label: "Heading", widget: string, maxlength: 80 }
+          - { name: body, label: "Body", widget: text, maxlength: 200 }
+          - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+          - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
+      - name: details
+        label: "Detail rows (shown on the event page)"
+        widget: list
+        required: false
+        summary: "{{label}}: {{value}}"
         fields:
-          - name: members
-            label: "Members"
-            label_singular: "Member"
-            widget: list
-            summary: "{{name}}"
-            fields:
-              - { name: name, label: "Name", widget: string }
-              - name: tags
-                label: "Tags"
-                widget: relation
-                collection: about_d3i
-                file: team_tags
-                value_field: "{{tags.*.label}}"
-                display_fields: ["{{tags.*.label}}"]
-                search_fields: ["{{tags.*.label}}"]
-                multiple: true
-                required: false
-                hint: "This person's roles, projects, and affiliations. These drive the filter chips on the Team page. To add a new tag, edit 'Team tags' first."
-              - name: image
-                label: "Photo"
-                widget: image
-                media_folder: /assets/images/people
-                public_folder: /assets/images/people
-                choose_url: false
-                max_file_size: 2097152
-                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
-              - { name: url, label: "Profile URL", widget: string, required: false }
-
-      - file: _data/team_tags.yml
-        name: team_tags
-        label: "Team tags"
-        icon: label
-        format: yml
-        description: "The tag vocabulary for the Team page (the filter chips). Add a tag here, then assign it to people in Team members. Order = chip order on the page."
+          - { name: label, label: "Label", widget: string }
+          - { name: value, label: "Value", widget: string }
+          - { name: markdown, label: "Value contains markdown?", widget: boolean, required: false, default: false }
+      - name: actions
+        label: "Action buttons"
+        widget: list
+        required: false
+        summary: "{{label}} → {{url}}"
         fields:
-          - name: tags
-            label: "Tags"
-            label_singular: "Tag"
-            widget: list
-            summary: "{{label}}"
-            fields:
-              - { name: label, label: "Display label", widget: string, hint: "Shown as the filter chip and the badge on each card. The internal id used for filtering is generated automatically." }
+          - { name: label, label: "Button label", widget: string }
+          - { name: url, label: "URL", widget: string }
+          - { name: external, label: "External link?", widget: boolean, required: false, default: true }
+      - { name: redirect_from, widget: hidden, required: false }
+      - { name: layout, widget: hidden, default: "page" }
+      - { name: sidebar, widget: hidden, default: { nav: "community" } }
+      - { name: body, label: "Full event page content (markdown)", widget: markdown }
 
-      - { divider: true, label: "Advisory board" }
-      - file: _pages/about-d3i/advisory-board.md
-        name: advisory_board_page
-        label: "Advisory board page"
-        icon: article
-        description: "The intro prose at /about-d3i/advisory-board. Advisors themselves are edited in the next entry."
-        fields:
-          - { name: title, label: "Page title", widget: string }
-          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
-          - name: body
-            label: "Intro prose (markdown)"
-            widget: markdown
-            hint: "Short prose shown above the advisors list."
-          - name: contact
-            label: "Contact CTA"
-            widget: object
-            collapsed: true
-            summary: "{{lead}}"
-            comment: "Renders as the contact CTA block at the bottom of the page."
-            fields:
-              - { name: lead, label: "Heading", widget: string }
-              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
-              - name: bullets
-                label: "Bullet points (optional)"
-                widget: list
-                required: false
-                field: { name: bullet, widget: string }
-              - { name: email, label: "Email address", widget: string, type: email }
-              - { name: subject, label: "Email subject", widget: string }
-          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
-          - { name: data_section, widget: hidden, default: { type: "link-list", data: "advisors" } }
-          - { name: permalink, widget: hidden, default: "/about-d3i/advisory-board" }
-          - { name: layout, widget: hidden, default: "page" }
-          - { name: redirect_from, widget: hidden, default: ["/about-the-project/advisory-board"] }
+  # ──────────────── News (entry collection) ───────────────────────────────
+  # Folder collection for news items. Each item appears on /news/ and,
+  # while fresh (under ~3 months old), in the homepage "Latest news" strip.
+  # The freshness window is enforced at build time AND client-side
+  # (assets/js/news-freshness.js), so old items drop off the homepage even
+  # when the site isn't rebuilt for months.
+  - name: news
+    label: "News"
+    icon: newspaper
+    folder: _news
+    create: true
+    extension: md
+    format: yaml-frontmatter
+    slug: "{{fields.date | date('YYYY-MM-DD')}}-{{slug}}"
+    summary: "{{title}} — {{date | date('D MMM YYYY')}}"
+    thumbnail: image
+    sortable_fields:
+      fields: [date, title]
+      default:
+        field: date
+        direction: descending
+    view_groups:
+      - label: "Year"
+        field: date
+        pattern: '\d{4}'
+    description: "News items shown on /news/ and, while fresh (under ~3 months old), in the homepage 'Latest news' strip. For a story that lives elsewhere (e.g. a partner site), fill in the External URL field — cards then link straight there and the body may stay empty. Add a new item with the '+' button."
+    fields:
+      - { name: title, label: "Title", widget: string }
+      - name: date
+        label: "Date"
+        widget: datetime
+        type: date
+        comment: "Publication date. Newest items appear first; items older than ~3 months drop off the homepage strip automatically (they stay on /news/)."
+      - { name: summary, label: "Short summary (used in cards)", widget: text }
+      - name: image
+        label: "Image (optional)"
+        widget: image
+        required: false
+        media_folder: /assets/images/news
+        public_folder: /assets/images/news
+        choose_url: false
+        max_file_size: 2097152
+        accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+      - { name: image_alt, label: "Image alt text", widget: string, required: false, comment: "Describe the image for screen readers. Fill in whenever an image is set." }
+      - { name: external_url, label: "External URL (optional)", widget: string, required: false, comment: "If the story lives elsewhere, put its URL here — cards link straight out and the body below may stay empty." }
+      - { name: layout, widget: hidden, default: "page" }
+      - { name: body, label: "Full news item content (markdown)", widget: markdown, required: false }
 
-      - file: _data/advisors.yml
-        name: advisors_data
-        label: "Advisors"
-        icon: support_agent
-        format: yml
-        description: "Members of the advisory board (rendered on /about-d3i/advisory-board)."
-        fields:
-          - name: advisors
-            label: "Advisors"
-            label_singular: "Advisor"
-            widget: list
-            summary: "{{name}}"
-            fields:
-              - { name: name, label: "Name", widget: string }
-              - { name: url, label: "Profile URL", widget: string, required: false }
-
-      - { divider: true, label: "Funding" }
-      - file: _pages/about-d3i/funding.md
-        name: funding_page
-        label: "Funding page"
-        icon: article
-        description: "The intro prose at /about-d3i/funding. Funding entries themselves are edited in the next entry."
-        fields:
-          - { name: title, label: "Page title", widget: string }
-          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
-          - name: body
-            label: "Intro prose (markdown)"
-            widget: markdown
-            hint: "Short prose shown above the funding entries."
-          - name: contact
-            label: "Contact CTA"
-            widget: object
-            collapsed: true
-            summary: "{{lead}}"
-            comment: "Renders as the contact CTA block at the bottom of the page."
-            fields:
-              - { name: lead, label: "Heading", widget: string }
-              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
-              - name: bullets
-                label: "Bullet points (optional)"
-                widget: list
-                required: false
-                field: { name: bullet, widget: string }
-              - { name: email, label: "Email address", widget: string, type: email }
-              - { name: subject, label: "Email subject", widget: string }
-          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
-          - { name: data_section, widget: hidden, default: { type: "funding-list", data: "funding" } }
-          - { name: permalink, widget: hidden, default: "/about-d3i/funding" }
-          - { name: layout, widget: hidden, default: "page" }
-          - { name: redirect_from, widget: hidden, default: ["/about-the-project/funding"] }
-
-      - file: _data/funding.yml
-        name: funding_data
-        label: "Funding entries"
-        icon: payments
-        format: yml
-        description: "Grants and funders (rendered on /about-d3i/funding)."
-        fields:
-          - name: funding
-            label: "Funding entries"
-            label_singular: "Funding entry"
-            widget: list
-            summary: "{{title}}"
-            fields:
-              - { name: title, label: "Title", widget: string }
-              - { name: period, label: "Period (e.g. 2024 – 2028, or 'permanent')", widget: string, required: false }
-              - { name: funder, label: "Funder", widget: string }
-              - { name: url, label: "Link (optional)", widget: string, required: false }
-              - { name: description, label: "Description", widget: text }
-
-      - { divider: true, label: "Partners" }
-      - file: _pages/about-d3i/partners.md
-        name: partners_page
-        label: "Partners page"
-        icon: article
-        description: "The intro prose at /about-d3i/partners. Partner entries themselves are edited in the next entry."
-        fields:
-          - { name: title, label: "Page title", widget: string }
-          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
-          - name: body
-            label: "Intro prose (markdown — optional)"
-            widget: markdown
-            required: false
-            hint: "Optional intro prose shown above the partners list. Leave blank if none."
-          - name: contact
-            label: "Contact CTA"
-            widget: object
-            collapsed: true
-            summary: "{{lead}}"
-            comment: "Renders as the contact CTA block at the bottom of the page."
-            fields:
-              - { name: lead, label: "Heading", widget: string }
-              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
-              - name: bullets
-                label: "Bullet points (optional)"
-                widget: list
-                required: false
-                field: { name: bullet, widget: string }
-              - { name: email, label: "Email address", widget: string, type: email }
-              - { name: subject, label: "Email subject", widget: string }
-          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
-          - { name: data_section, widget: hidden, default: { type: "info-list", data: "partners" } }
-          - { name: permalink, widget: hidden, default: "/about-d3i/partners" }
-          - { name: layout, widget: hidden, default: "page" }
-          - { name: redirect_from, widget: hidden, default: ["/about-the-project/partners"] }
-
-      - file: _data/partners.yml
-        name: partners_data
-        label: "Partners"
-        icon: handshake
-        format: yml
-        description: "Partner organizations (rendered on /about-d3i/partners)."
-        fields:
-          - name: partners
-            label: "Partners"
-            label_singular: "Partner"
-            widget: list
-            summary: "{{name}}"
-            fields:
-              - { name: name, label: "Name", widget: string }
-              - { name: url, label: "Website", widget: string, required: false }
-              - { name: role, label: "Role / relationship", widget: string, required: false }
-              - { name: description, label: "Description", widget: text }
-
-      - { divider: true, label: "Impact and adoption" }
-      - file: _pages/about-d3i/impact-and-adoption.md
-        name: impact_page
-        label: "Impact and adoption page"
-        icon: article
-        description: "The Impact and adoption page, including usage plots and the 'help us track' CTA."
-        fields:
-          - { name: title, label: "Page title", widget: string }
-          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
-          - name: body
-            label: "Page body (markdown)"
-            widget: markdown
-            hint: "Prose for the page. The 'Usage plots' field below is rendered automatically after this body — do not add image includes here."
-          - name: cta
-            label: "Call-to-action button"
-            widget: object
-            required: false
-            collapsed: true
-            summary: "{{label}}"
-            comment: "Optional styled button rendered immediately after the body, before the bottom contact block. Leave blank if none."
-            fields:
-              - { name: label, label: "Button text", widget: string, comment: "Don't include the arrow — the layout adds it." }
-              - { name: url, label: "URL or mailto link", widget: string, comment: "e.g. https://example.com/form or mailto:foo@bar." }
-          - name: usage_images
-            label: "Usage plots"
-            widget: list
-            required: false
-            summary: "{{caption}}"
-            fields:
-              - name: image
-                label: "Plot image"
-                widget: image
-                media_folder: /assets/images/usage
-                public_folder: /assets/images/usage
-                choose_url: false
-                max_file_size: 2097152
-                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
-              - { name: caption, label: "Caption (also used as alt text)", widget: string }
-          - name: contact
-            label: "Contact CTA"
-            widget: object
-            collapsed: true
-            summary: "{{lead}}"
-            comment: "Renders as the contact CTA block at the bottom of the page."
-            fields:
-              - { name: lead, label: "Heading", widget: string }
-              - { name: intro, label: "Intro text", widget: string, required: false }
-              - name: bullets
-                label: "Bullet points (optional)"
-                widget: list
-                required: false
-                field: { name: bullet, widget: string }
-              - { name: email, label: "Email address", widget: string, type: email }
-              - { name: subject, label: "Email subject", widget: string }
-          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
-          - { name: permalink, widget: hidden, default: "/about-d3i/impact-and-adoption" }
-          - { name: layout, widget: hidden, default: "page" }
-          - { name: redirect_from, widget: hidden, default: ["/software/usage/"] }
-
-      - file: _data/usage.yml
-        name: usage_data
-        label: "Usage figures data"
-        icon: insights
-        format: yml
-        description: "Numbers behind the figures on the Impact & adoption page."
-        fields:
-          - name: studies_per_year
-            label: "Studies per year figure"
-            label_singular: "Year total"
-            widget: list
-            summary: "{{year}}: {{count}}"
-            fields:
-              - { name: year, label: "Year", widget: string }
-              - { name: count, label: "Total studies", widget: number, value_type: int }
-          # Country colours, order, and fallback centroids — maintained by a
-          # developer directly in _data/usage.yml. Hidden (not deleted) so the
-          # CMS preserves it on save instead of dropping it.
-          - { name: countries, label: "Countries", widget: hidden }
-          - name: institutions
-            label: "Institutions"
-            widget: list
-            summary: "{{name}}"
-            fields:
-              - { name: name, label: "Institution name", widget: string }
-              - { name: country, label: "Country", widget: string }
-              # Map coordinates — a developer adds these in _data/usage.yml.
-              # Hidden so a manager's save preserves them rather than wiping them.
-              - { name: lat, widget: hidden }
-              - { name: lng, widget: hidden }
-          - name: platforms
-            label: "Platforms"
-            widget: list
-            summary: "{{name}}"
-            fields:
-              - { name: name, label: "Platform name", widget: string }
-              - name: category
-                label: "Category"
-                widget: select
-                options: ["Social & video", "Professional & messaging", "Streaming & audio", "AI & search", "Google ecosystem", "Health & wearables"]
+  # ───────────── Site sections (page editors + data lists) ────────────────
+  - divider: true
 
   # ──────────────────────── Community ─────────────────────────────────────
   - name: community
@@ -409,6 +232,153 @@ collections:
     icon: forum
     description: "Pages and data lists under Community (/community/)."
     files:
+
+      - { divider: true, label: "Events page" }
+      - file: _pages/community/events/index.md
+        name: events_page
+        label: "Events page"
+        icon: article
+        description: "The intro prose at /community/events/. Event entries themselves are edited in the Events collection at the top of the sidebar."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
+          - name: body
+            label: "Intro prose (markdown)"
+            widget: markdown
+            hint: "Short prose shown above the events archive."
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: sidebar, widget: hidden, default: { nav: "community" } }
+          - { name: hero, widget: hidden, default: { image: "/assets/images/hub/undraw_conference-speaker_kl0d.svg", alt: "A person presenting at a conference." } }
+          - { name: archive, widget: hidden, default: { collection: "events", featured_heading: "Next up", upcoming_heading: "Also upcoming", heading: "Previous events" } }
+          - { name: toc, widget: hidden, default: false }
+          - { name: permalink, widget: hidden, default: "/community/events/" }
+          - { name: layout, widget: hidden, default: "page-archive-stacked" }
+
+      - { divider: true, label: "Courses" }
+      - file: _pages/community/courses/index.md
+        name: courses_page
+        label: "Courses page"
+        icon: article
+        description: "The intro prose at /community/courses/. Course entries themselves are edited in the Events collection (with event type 'Course')."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
+          - name: body
+            label: "Intro prose (markdown)"
+            widget: markdown
+            hint: "Short prose shown above the course archive."
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: sidebar, widget: hidden, default: { nav: "community" } }
+          - { name: hero, widget: hidden, default: { image: "/assets/images/hub/undraw_group-project_kow1.svg", alt: "A group of people collaborating on a project together." } }
+          - { name: archive, widget: hidden, default: { collection: "events", type: "course", featured_heading: "Upcoming course", upcoming_heading: "Also upcoming", heading: "Previous courses" } }
+          - { name: toc, widget: hidden, default: false }
+          - { name: permalink, widget: hidden, default: "/community/courses/" }
+          - { name: layout, widget: hidden, default: "page-archive-stacked" }
+
+      - { divider: true, label: "Symposia" }
+      - file: _pages/community/symposia/index.md
+        name: symposia_page
+        label: "Symposia page"
+        icon: article
+        description: "The intro prose at /community/symposia/. Symposium entries themselves are edited in the Events collection (with event type 'Symposium')."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
+          - name: body
+            label: "Intro prose (markdown)"
+            widget: markdown
+            hint: "Short prose shown above the symposia archive."
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: sidebar, widget: hidden, default: { nav: "community" } }
+          - { name: hero, widget: hidden, default: { image: "/assets/images/hub/undraw_conference-speaker_kl0d.svg", alt: "A person presenting at a conference." } }
+          - { name: archive, widget: hidden, default: { collection: "events", type: "symposium", featured_heading: "Upcoming symposium", heading: "Previous symposia" } }
+          - { name: toc, widget: hidden, default: false }
+          - { name: permalink, widget: hidden, default: "/community/symposia/" }
+          - { name: layout, widget: hidden, default: "page-archive-stacked" }
 
       - { divider: true, label: "Networks" }
       - file: _pages/community/network.md
@@ -496,6 +466,8 @@ collections:
         icon: business
         format: yml
         description: "Partner institutions shown on the Community Networks page."
+        editor:
+          preview: false
         fields:
           - name: institutions
             label: "Institutions"
@@ -575,6 +547,8 @@ collections:
         icon: mail
         format: yml
         description: "Newsletter issues linked from the Newsletter page."
+        editor:
+          preview: false
         fields:
           - name: newsletters
             label: "Newsletters"
@@ -588,32 +562,26 @@ collections:
               - { name: summary, label: "Summary", widget: text }
               - { name: link_text, label: "Link text (e.g. 'Open newsletter')", widget: string, required: false }
 
-      - { divider: true, label: "Courses" }
-      - file: _pages/community/courses/index.md
-        name: courses_page
-        label: "Courses page"
+  # ──────────────────────── About D3I ─────────────────────────────────────
+  - name: about_d3i
+    label: "About D3I"
+    icon: account_balance
+    description: "Pages and data lists under About D3I (/about-d3i/)."
+    files:
+
+      - { divider: true, label: "Team" }
+      - file: _pages/about-d3i/team.md
+        name: team_page
+        label: "Team page"
         icon: article
-        description: "The intro prose at /community/courses/. Course entries themselves are edited in the Events collection (with event type 'Course')."
+        description: "The intro prose at /about-d3i/team. Team members themselves are edited in the next entry."
         fields:
           - { name: title, label: "Page title", widget: string }
           - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
-          - name: postit
-            label: "Highlight (optional)"
-            widget: object
-            required: false
-            collapsed: true
-            summary: "{{title}}"
-            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
-            fields:
-              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
-              - { name: title, label: "Heading", widget: string, maxlength: 80 }
-              - { name: body, label: "Body", widget: text, maxlength: 200 }
-              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
-              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
           - name: body
             label: "Intro prose (markdown)"
             widget: markdown
-            hint: "Short prose shown above the course archive."
+            hint: "Short prose shown above the team grid. Keep it brief — the grid itself is the main content."
           - name: contact
             label: "Contact CTA"
             widget: object
@@ -630,141 +598,332 @@ collections:
                 field: { name: bullet, widget: string }
               - { name: email, label: "Email address", widget: string, type: email }
               - { name: subject, label: "Email subject", widget: string }
-          - { name: sidebar, widget: hidden, default: { nav: "community" } }
-          - { name: hero, widget: hidden, default: { image: "/assets/images/hub/undraw_group-project_kow1.svg", alt: "A group of people collaborating on a project together." } }
-          - { name: archive, widget: hidden, default: { collection: "events", type: "course", featured_heading: "Upcoming course", upcoming_heading: "Also upcoming", heading: "Previous courses" } }
-          - { name: toc, widget: hidden, default: false }
-          - { name: permalink, widget: hidden, default: "/community/courses/" }
-          - { name: layout, widget: hidden, default: "page-archive-stacked" }
+          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
+          - { name: data_section, widget: hidden, default: { type: "people-grid", data: "team" } }
+          - { name: permalink, widget: hidden, default: "/about-d3i/team" }
+          - { name: layout, widget: hidden, default: "page" }
+          - { name: redirect_from, widget: hidden, default: ["/about-the-project/team", "/d3i/team"] }
 
-  # ──────────────── Events (peer to Community — entry collection) ─────────
-  # Folder collections cannot nest inside file collections, so Events sits
-  # as a sibling to the Community section collection. The deliberate
-  # decision: every event we acknowledge gets an `_events/` page (even if
-  # the body is bare and the page mostly links out via external_url). One
-  # collection, one rendering pattern, no separate "link-only" data file.
-  # The Courses and Symposia pages are typed views of this collection
-  # (archive.type in their frontmatter); /community/events/ shows everything.
-  - name: events
-    label: "Events"
-    icon: event
-    folder: _events
-    create: true
-    extension: md
-    format: yaml-frontmatter
-    slug: "{{fields.date | date('YYYY')}}-{{slug}}"
-    summary: "{{title}} — {{date}}"
-    description: "Event pages for symposia, courses, workshops, and other events. Each entry produces its own page on this site. For events whose primary page lives elsewhere, fill in the External URL field — the manager can still write a brief frontmatter entry here so the event appears in the events archive. Add a new event with the '+' button."
-    fields:
-      - { name: title, label: "Title", widget: string }
-      - name: event_type
-        label: "Event type"
-        widget: select
-        options:
-          - { label: "Symposium", value: symposium }
-          - { label: "Course", value: course }
-          - { label: "Workshop", value: workshop }
-          - { label: "Lecture", value: lecture }
-          - { label: "Other", value: other }
-        comment: "Controls which archive pages list this event: the Courses page shows 'Course', the Symposia page shows 'Symposium', and every type appears on /community/events/."
-      - name: date
-        label: "Start date"
-        widget: datetime
-        type: date
-        comment: "Used to determine if the event is upcoming or past."
-      - name: end_date
-        label: "End date"
-        widget: datetime
-        type: date
-        required: false
-        comment: "Optional. If set, used for the upcoming/past decision instead of start date."
-      - name: date_label
-        label: "Date label (optional)"
-        widget: string
-        required: false
-        comment: "Optional display override for the date on cards, e.g. 'July 2025' when the exact day is unknown. The start date above still controls sorting and the upcoming/past split."
-      - { name: location, label: "Location", widget: string }
-      - { name: summary, label: "Short summary (used in cards)", widget: text }
-      - name: featured
-        label: "Spotlight this event?"
-        widget: boolean
-        required: false
-        default: false
-        comment: "Spotlights this event in the upcoming-event hero slot on the archive pages that list it. Only meaningful for upcoming events; past events ignore this flag (the layout uses dates to classify upcoming vs. past automatically)."
-      - name: postit
-        label: "Highlight (optional)"
-        widget: object
-        required: false
-        collapsed: true
-        summary: "{{title}}"
-        comment: "Optional time-sensitive highlight box rendered at the top of this event's page. Useful for things like 'Registration closes Friday' or 'Programme updated'. Leave the checkbox unchecked when not in use."
+      - file: _data/team.yml
+        name: team_members
+        label: "Team members"
+        icon: people
+        format: yml
+        description: "People listed on the Team page, tagged by role."
+        editor:
+          preview: false
         fields:
-          - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
-          - { name: title, label: "Heading", widget: string, maxlength: 80 }
-          - { name: body, label: "Body", widget: text, maxlength: 200 }
-          - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
-          - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
-      - { name: external_url, label: "External URL (event website)", widget: string, required: false }
-      - name: details
-        label: "Detail rows (shown on the event page)"
-        widget: list
-        required: false
-        summary: "{{label}}: {{value}}"
-        fields:
-          - { name: label, label: "Label", widget: string }
-          - { name: value, label: "Value", widget: string }
-          - { name: markdown, label: "Value contains markdown?", widget: boolean, required: false, default: false }
-      - name: actions
-        label: "Action buttons"
-        widget: list
-        required: false
-        summary: "{{label}} → {{url}}"
-        fields:
-          - { name: label, label: "Button label", widget: string }
-          - { name: url, label: "URL", widget: string }
-          - { name: external, label: "External link?", widget: boolean, required: false, default: true }
-      - { name: redirect_from, widget: hidden, required: false }
-      - { name: layout, widget: hidden, default: "page" }
-      - { name: sidebar, widget: hidden, default: { nav: "community" } }
-      - { name: body, label: "Full event page content (markdown)", widget: markdown }
+          - name: members
+            label: "Members"
+            label_singular: "Member"
+            widget: list
+            summary: "{{name}}"
+            fields:
+              - { name: name, label: "Name", widget: string }
+              - name: tags
+                label: "Tags"
+                widget: relation
+                collection: about_d3i
+                file: team_tags
+                value_field: "{{tags.*.label}}"
+                display_fields: ["{{tags.*.label}}"]
+                search_fields: ["{{tags.*.label}}"]
+                multiple: true
+                required: false
+                hint: "This person's roles, projects, and affiliations. These drive the filter chips on the Team page. To add a new tag, edit 'Team tags' first."
+              - name: image
+                label: "Photo"
+                widget: image
+                media_folder: /assets/images/people
+                public_folder: /assets/images/people
+                choose_url: false
+                max_file_size: 2097152
+                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+              - { name: url, label: "Profile URL", widget: string, required: false }
 
-  # ──────────────── News (peer to Community — entry collection) ───────────
-  # Folder collection for news items. Each item appears on /news/ and,
-  # while fresh (under ~3 months old), in the homepage "Latest news" strip.
-  # The freshness window is enforced at build time AND client-side
-  # (assets/js/news-freshness.js), so old items drop off the homepage even
-  # when the site isn't rebuilt for months.
-  - name: news
-    label: "News"
-    icon: newspaper
-    folder: _news
-    create: true
-    extension: md
-    format: yaml-frontmatter
-    slug: "{{fields.date | date('YYYY-MM-DD')}}-{{slug}}"
-    summary: "{{title}} — {{date}}"
-    description: "News items shown on /news/ and, while fresh (under ~3 months old), in the homepage 'Latest news' strip. For a story that lives elsewhere (e.g. a partner site), fill in the External URL field — cards then link straight there and the body may stay empty. Add a new item with the '+' button."
-    fields:
-      - { name: title, label: "Title", widget: string }
-      - name: date
-        label: "Date"
-        widget: datetime
-        type: date
-        comment: "Publication date. Newest items appear first; items older than ~3 months drop off the homepage strip automatically (they stay on /news/)."
-      - { name: summary, label: "Short summary (used in cards)", widget: text }
-      - name: image
-        label: "Image (optional)"
-        widget: image
-        required: false
-        media_folder: /assets/images/news
-        public_folder: /assets/images/news
-        choose_url: false
-        max_file_size: 2097152
-        accept: "image/jpeg,image/png,image/svg+xml,image/webp"
-      - { name: image_alt, label: "Image alt text", widget: string, required: false, comment: "Describe the image for screen readers. Fill in whenever an image is set." }
-      - { name: external_url, label: "External URL (optional)", widget: string, required: false, comment: "If the story lives elsewhere, put its URL here — cards link straight out and the body below may stay empty." }
-      - { name: layout, widget: hidden, default: "page" }
-      - { name: body, label: "Full news item content (markdown)", widget: markdown, required: false }
+      - file: _data/team_tags.yml
+        name: team_tags
+        label: "Team tags"
+        icon: label
+        format: yml
+        description: "The tag vocabulary for the Team page (the filter chips). Add a tag here, then assign it to people in Team members. Order = chip order on the page."
+        editor:
+          preview: false
+        fields:
+          - name: tags
+            label: "Tags"
+            label_singular: "Tag"
+            widget: list
+            summary: "{{label}}"
+            fields:
+              - { name: label, label: "Display label", widget: string, hint: "Shown as the filter chip and the badge on each card. The internal id used for filtering is generated automatically." }
+
+      - { divider: true, label: "Advisory board" }
+      - file: _pages/about-d3i/advisory-board.md
+        name: advisory_board_page
+        label: "Advisory board page"
+        icon: article
+        description: "The intro prose at /about-d3i/advisory-board. Advisors themselves are edited in the next entry."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: body
+            label: "Intro prose (markdown)"
+            widget: markdown
+            hint: "Short prose shown above the advisors list."
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
+          - { name: data_section, widget: hidden, default: { type: "link-list", data: "advisors" } }
+          - { name: permalink, widget: hidden, default: "/about-d3i/advisory-board" }
+          - { name: layout, widget: hidden, default: "page" }
+          - { name: redirect_from, widget: hidden, default: ["/about-the-project/advisory-board"] }
+
+      - file: _data/advisors.yml
+        name: advisors_data
+        label: "Advisors"
+        icon: support_agent
+        format: yml
+        description: "Members of the advisory board (rendered on /about-d3i/advisory-board)."
+        editor:
+          preview: false
+        fields:
+          - name: advisors
+            label: "Advisors"
+            label_singular: "Advisor"
+            widget: list
+            summary: "{{name}}"
+            fields:
+              - { name: name, label: "Name", widget: string }
+              - { name: url, label: "Profile URL", widget: string, required: false }
+
+      - { divider: true, label: "Funding" }
+      - file: _pages/about-d3i/funding.md
+        name: funding_page
+        label: "Funding page"
+        icon: article
+        description: "The intro prose at /about-d3i/funding. Funding entries themselves are edited in the next entry."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: body
+            label: "Intro prose (markdown)"
+            widget: markdown
+            hint: "Short prose shown above the funding entries."
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
+          - { name: data_section, widget: hidden, default: { type: "funding-list", data: "funding" } }
+          - { name: permalink, widget: hidden, default: "/about-d3i/funding" }
+          - { name: layout, widget: hidden, default: "page" }
+          - { name: redirect_from, widget: hidden, default: ["/about-the-project/funding"] }
+
+      - file: _data/funding.yml
+        name: funding_data
+        label: "Funding entries"
+        icon: payments
+        format: yml
+        description: "Grants and funders (rendered on /about-d3i/funding)."
+        editor:
+          preview: false
+        fields:
+          - name: funding
+            label: "Funding entries"
+            label_singular: "Funding entry"
+            widget: list
+            summary: "{{title}}"
+            fields:
+              - { name: title, label: "Title", widget: string }
+              - { name: period, label: "Period (e.g. 2024 – 2028, or 'permanent')", widget: string, required: false }
+              - { name: funder, label: "Funder", widget: string }
+              - { name: url, label: "Link (optional)", widget: string, required: false }
+              - { name: description, label: "Description", widget: text }
+
+      - { divider: true, label: "Partners" }
+      - file: _pages/about-d3i/partners.md
+        name: partners_page
+        label: "Partners page"
+        icon: article
+        description: "The intro prose at /about-d3i/partners. Partner entries themselves are edited in the next entry."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: body
+            label: "Intro prose (markdown — optional)"
+            widget: markdown
+            required: false
+            hint: "Optional intro prose shown above the partners list. Leave blank if none."
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
+          - { name: data_section, widget: hidden, default: { type: "info-list", data: "partners" } }
+          - { name: permalink, widget: hidden, default: "/about-d3i/partners" }
+          - { name: layout, widget: hidden, default: "page" }
+          - { name: redirect_from, widget: hidden, default: ["/about-the-project/partners"] }
+
+      - file: _data/partners.yml
+        name: partners_data
+        label: "Partners"
+        icon: handshake
+        format: yml
+        description: "Partner organizations (rendered on /about-d3i/partners)."
+        editor:
+          preview: false
+        fields:
+          - name: partners
+            label: "Partners"
+            label_singular: "Partner"
+            widget: list
+            summary: "{{name}}"
+            fields:
+              - { name: name, label: "Name", widget: string }
+              - { name: url, label: "Website", widget: string, required: false }
+              - { name: role, label: "Role / relationship", widget: string, required: false }
+              - { name: description, label: "Description", widget: text }
+
+      - { divider: true, label: "Impact and adoption" }
+      - file: _pages/about-d3i/impact-and-adoption.md
+        name: impact_page
+        label: "Impact and adoption page"
+        icon: article
+        description: "The Impact and adoption page, including usage plots and the 'help us track' CTA."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: body
+            label: "Page body (markdown)"
+            widget: markdown
+            hint: "Prose for the page. The 'Usage plots' field below is rendered automatically after this body — do not add image includes here."
+          - name: cta
+            label: "Call-to-action button"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{label}}"
+            comment: "Optional styled button rendered immediately after the body, before the bottom contact block. Leave blank if none."
+            fields:
+              - { name: label, label: "Button text", widget: string, comment: "Don't include the arrow — the layout adds it." }
+              - { name: url, label: "URL or mailto link", widget: string, comment: "e.g. https://example.com/form or mailto:foo@bar." }
+          - name: usage_images
+            label: "Usage plots"
+            widget: list
+            required: false
+            summary: "{{caption}}"
+            fields:
+              - name: image
+                label: "Plot image"
+                widget: image
+                media_folder: /assets/images/usage
+                public_folder: /assets/images/usage
+                choose_url: false
+                max_file_size: 2097152
+                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+              - { name: caption, label: "Caption (also used as alt text)", widget: string }
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
+          - { name: permalink, widget: hidden, default: "/about-d3i/impact-and-adoption" }
+          - { name: layout, widget: hidden, default: "page" }
+          - { name: redirect_from, widget: hidden, default: ["/software/usage/"] }
+
+      - file: _data/usage.yml
+        name: usage_data
+        label: "Usage figures data"
+        icon: insights
+        format: yml
+        description: "Numbers behind the figures on the Impact & adoption page."
+        editor:
+          preview: false
+        fields:
+          - name: studies_per_year
+            label: "Studies per year figure"
+            label_singular: "Year total"
+            widget: list
+            summary: "{{year}}: {{count}}"
+            fields:
+              - { name: year, label: "Year", widget: string }
+              - { name: count, label: "Total studies", widget: number, value_type: int }
+          # Country colours, order, and fallback centroids — maintained by a
+          # developer directly in _data/usage.yml. Hidden (not deleted) so the
+          # CMS preserves it on save instead of dropping it.
+          - { name: countries, label: "Countries", widget: hidden }
+          - name: institutions
+            label: "Institutions"
+            widget: list
+            summary: "{{name}}"
+            fields:
+              - { name: name, label: "Institution name", widget: string }
+              - { name: country, label: "Country", widget: string }
+              # Map coordinates — a developer adds these in _data/usage.yml.
+              # Hidden so a manager's save preserves them rather than wiping them.
+              - { name: lat, widget: hidden }
+              - { name: lng, widget: hidden }
+          - name: platforms
+            label: "Platforms"
+            widget: list
+            summary: "{{name}}"
+            fields:
+              - { name: name, label: "Platform name", widget: string }
+              - name: category
+                label: "Category"
+                widget: select
+                options: ["Social & video", "Professional & messaging", "Streaming & audio", "AI & search", "Google ecosystem", "Health & wearables"]
 
   # ──────────────────────── Prepare a Study ───────────────────────────────
   - name: prepare_a_study
@@ -813,6 +972,8 @@ collections:
         icon: inventory_2
         format: yml
         description: "Finished studies shown on the Completed projects page."
+        editor:
+          preview: false
         fields:
           - name: completed_projects
             label: "Projects"

--- a/admin/index.html
+++ b/admin/index.html
@@ -4,9 +4,15 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, nofollow">
-  <title>Content Manager</title>
+  <link rel="icon" href="/assets/images/favicon.svg" type="image/svg+xml">
+  <title>datadonation.eu admin</title>
 </head>
 <body>
   <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
+  <script>
+    // Make the entry preview pane read like the site (fonts, colors,
+    // measure). The stylesheet only affects the preview, not the app UI.
+    CMS.registerPreviewStyle('/admin/preview.css');
+  </script>
 </body>
 </html>

--- a/admin/preview.css
+++ b/admin/preview.css
@@ -1,0 +1,83 @@
+/* Preview-pane styles for the CMS (registered in admin/index.html via
+   CMS.registerPreviewStyle). Mirrors the site's typography so the preview
+   reads like datadonation.eu — the preview DOM is generic (not the site's
+   markup), so this stays at the element level: fonts, colors, measure.
+   Tokens come from _sass/_variables.scss; keep the two in sync. */
+
+@font-face {
+  font-family: "Nunito";
+  src: url("/assets/fonts/Nunito.woff2") format("woff2");
+  font-weight: 200 900;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  src: url("/assets/fonts/NunitoSans-VariableFont_wght.woff2") format("woff2");
+  font-weight: 200 1000;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Nunito Sans";
+  src: url("/assets/fonts/NunitoSans-Italic-VariableFont_wght.woff2") format("woff2");
+  font-weight: 200 1000;
+  font-style: italic;
+}
+
+body {
+  background: #ffffff;
+  color: #333333;
+  font-family: "Nunito Sans", -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  max-width: 54rem; /* $content-width */
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
+  font-weight: 800;
+  color: #333333;
+  line-height: 1.25;
+}
+
+a {
+  color: #4272EF; /* $accent-primary */
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.5rem;
+}
+
+blockquote {
+  margin: 1rem 0;
+  padding: 0.25rem 0 0.25rem 1rem;
+  border-left: 4px solid #4272EF;
+  color: #6a6a6a; /* $muted-text-color */
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid #e6e6e6; /* $border-color */
+}
+
+code {
+  font-family: Monaco, Consolas, "Lucida Console", monospace;
+  font-size: 0.9em;
+  background: #f5f5f5;
+  padding: 0.1em 0.3em;
+  border-radius: 0.25em;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #e6e6e6;
+  padding: 0.4em 0.7em;
+}

--- a/cms/community-manager-guide.md
+++ b/cms/community-manager-guide.md
@@ -38,18 +38,15 @@ If login fails: most often, your token has the wrong permissions. Re-generate fo
 
 ## The dashboard
 
-You'll see a left sidebar listing everything you can edit:
+The left sidebar puts your day-to-day work at the top, with the site-section editors below a separator:
 
-The sidebar groups everything you can edit by site section:
-
+- **Events** — create new event pages (symposia, courses, workshops, and more); edit existing ones. The list is grouped by year (like folders), newest first. Use the filter icon above the list to show only one event type. Each entry produces its own page on the site and is listed on `/community/events/`; the Courses and Symposia pages automatically show the entries of the matching type.
+- **News** — create news items, newest first; switch to grid view to see image thumbnails. Each item appears on `/news/` and, while fresh (under ~3 months old), in the homepage "Latest news" strip.
+- **Community** — page editors and data lists for `/community/` (Events page, Courses page, Symposia page, Networks, Newsletter).
 - **About D3I** — page editors and data lists for `/about-d3i/` (Team, Advisory board, Funding, Partners, Impact and adoption).
-- **Community** — page editors and data lists for `/community/` (Networks, Newsletter, Courses).
-- **Events** — create new event pages (symposia, courses, workshops, and more); edit existing ones. Each entry produces its own page on the site and is listed on `/community/events/`; the Courses and Symposia pages automatically show the entries of the matching type.
-- **News** — create news items. Each item appears on `/news/` and, while fresh (under ~3 months old), in the homepage "Latest news" strip.
 - **Prepare a Study** — page editor and data list for the Completed projects page.
-- **Site Structure** — site-wide configuration (Navigation). Rarely needs editing.
 
-Within each section, page editors are paired with their supporting data list (e.g. "Team page" sits next to "Team members"). Edit the page when you want to change the prose; edit the data list when you want to add, remove, or reorder items shown on the page.
+Within each section, page editors are paired with their supporting data list (e.g. "Team page" sits next to "Team members"). Edit the page when you want to change the prose; edit the data list when you want to add, remove, or reorder items shown on the page. The Events, Courses, and Symposia pages are the exception: their intro prose is a page editor under Community, while the events listed on them come from the Events collection at the top of the sidebar.
 
 ## Common tasks
 
@@ -91,15 +88,16 @@ News items appear on the News page immediately after publication. The homepage "
 
 Every time you click **Save**, the CMS commits your edit to a behind-the-scenes branch called `cms-staging`. **The change is recorded but not yet visible on the live site.** This lets you make a series of edits in one sitting without each one immediately going live — useful for typo fixes, preview-and-revise cycles, or batches of related updates.
 
-The CMS doesn't have a separate "Publish" button. To make your accumulated edits visible to the public, you do the publishing step on GitHub (see below).
+To make your accumulated edits visible to the public, use the **Publish Changes** button (see below).
 
 ## Publishing your edits
 
-When you've finished a batch of edits and want them on the live site:
+When you've finished a batch of edits and want them on the live site, click **Publish Changes** in the bar at the top of the CMS. That's it — the publish workflow test-builds the site with your edits, publishes them, and rebuilds the staging site (2-3 min in total). If the build fails, nothing is published; email Danielle.
+
+If the button is ever missing or you want to watch the run, the same workflow can be started (and followed) from GitHub directly:
 
 1. Open https://github.com/d3i-website/d3i-website.github.io/actions/workflows/publish-cms-edits.yml in your browser.
-2. Click **Run workflow** (green button, top right of the list), then **Run workflow** again to confirm.
-3. Done. The workflow test-builds the site with your edits, publishes them, and rebuilds the staging site (2-3 min in total). If the build fails, nothing is published — the run shows a red ✗; email Danielle with a link to it.
+2. Click **Run workflow** (green button, top right of the list), then **Run workflow** again to confirm. Completed runs are listed on that same page — a red ✗ means the build failed and nothing was published; email Danielle with a link to it.
 
 Want to double-check what's going out first? Open https://github.com/d3i-website/d3i-website.github.io/compare/main...cms-staging to see every edit made since the last publication, then run the workflow when satisfied. If anything looks wrong in that diff, **don't publish** — email Danielle and describe what's off. She can help identify the issue or revert problem edits before publishing.
 

--- a/cms/maintainer-notes.md
+++ b/cms/maintainer-notes.md
@@ -7,7 +7,7 @@ Internal reference for the developer(s) maintaining the D3I Jekyll CMS.
 - **CMS engine**: Sveltia CMS (static JS bundle from CDN).
 - **Auth**: per-user GitHub fine-grained Personal Access Tokens (PATs). Each editor pastes their own token into Sveltia's "Sign in with Access Token" field on first use; Sveltia caches it in browser localStorage. No OAuth proxy is in the path.
 - **Backend**: the GitHub repo itself. Every edit is a git commit attributed to the PAT-owner's GitHub user.
-- **Branch model**: **CMS edits commit to `cms-staging`, not `main`.** `admin/config.yml` has `backend.branch: cms-staging`. Editors' Saves accumulate as small commits on `cms-staging`; publishing happens via a manual PR `cms-staging` → `main` (squash-merge) on the GitHub web UI.
+- **Branch model**: **CMS edits commit to `cms-staging`, not `main`.** `admin/config.yml` has `backend.branch: cms-staging`. Editors' Saves accumulate as small commits on `cms-staging`; publishing is the manager-triggered "Publish CMS edits" workflow (squash-merges `cms-staging` → `main`), started either from the **Publish Changes** button in the CMS header or from the Actions tab — see "Publish flow" below.
 - **Why not editorial workflow**: Sveltia's `publish_mode: editorial_workflow` is unimplemented (per their docs, planned for 1.0). The `cms-staging` branch model achieves the same goals (clean main history, batched email cost, review opportunity before publication) at the branch level instead of per-document.
 - **Admin URL**: https://d3i-website.github.io/admin/ (served by GitHub Pages from `admin/index.html`).
 
@@ -22,6 +22,23 @@ The `cms-staging` branch must stay in sync with `main` to avoid merge conflicts 
 **Manual fallback** (if the workflow is ever disabled or fails): `git push -f origin main:cms-staging`.
 
 **Avoid editing CMS-managed files directly on main.** When possible, route content changes through the CMS (commits to cms-staging, then publish). Reserve direct main edits for non-CMS files (layouts, scripts, configs).
+
+## Publish flow (skip_ci + repository_dispatch)
+
+`admin/config.yml` sets `backend.skip_ci: true`. This does two things:
+
+- **It surfaces a "Publish Changes" button in the CMS header.** Clicking it fires a `repository_dispatch` event of type `sveltia-cms-publish` against the default branch, which `.github/workflows/publish-cms-edits.yml` lists as a trigger alongside `workflow_dispatch`. So the manager publishes from inside the CMS; the Actions-tab "Run workflow" path remains as a fallback. Publishing stays fully manual either way — saves never auto-publish.
+- **Save commits to `cms-staging` get a `[skip ci]` message prefix** (deletions are exempted by Sveltia, by design). This is harmless here: no workflow builds off `cms-staging` pushes, and the publication squash-merge to `main` is performed with `GITHUB_TOKEN`, which never fires push-triggered workflows regardless of commit message — the publish workflow already compensates by dispatching the staging deploy and the branch reset explicitly. **Caveat**: if you ever merge `cms-staging` into `main` by hand (web UI or local), the squash commit body may inherit a `[skip ci]` line from a constituent commit and silently suppress push-triggered workflows (`deploy-staging`, `reset-cms-staging`); check for it before merging manually.
+
+## CMS appearance & entry-list views
+
+How the admin look-and-feel is configured (all in `admin/config.yml` unless noted):
+
+- **Branding**: `app_title` (login screen + browser tab) and `logo: { src: ... }` (replaces the deprecated `logo_url`). There is no supported way to theme/CSS the Sveltia app UI itself; light/dark follows each user's OS or their in-CMS Settings choice.
+- **Sidebar order**: collections are listed in manager-task order — Events and News (entry collections) first, then a top-level `- divider: true`, then the site-section file collections. Folder collections still cannot nest inside file collections, hence Events/News at top level.
+- **Entry-list views (Events)**: `sortable_fields` with a `default` of date-descending; `view_groups` grouping by year (regex `\d{4}` on `date`, `default: year`) to mirror the Bloomreach year-folder mental model; `view_filters` presets per `event_type`. Users can override sort/group/filter per-session via the toolbar; the config only sets defaults.
+- **Entry-list views (News)**: `thumbnail: image` (grid view shows the news image), date-descending default sort, optional year grouping (no default).
+- **Preview pane**: `admin/index.html` registers `admin/preview.css` via `CMS.registerPreviewStyle()` so entry previews use site typography (self-contained `@font-face` for the self-hosted Nunito fonts plus tokens copied from `_sass/_variables.scss` — keep in sync by hand). Data-list file editors set `editor: { preview: false }` because a preview of a raw YAML list is noise.
 
 ## Why PATs instead of OAuth (background)
 
@@ -116,7 +133,7 @@ For a page with known layout and frontmatter structure:
 - **Date widget**: Decap's `widget: date` is rejected by Sveltia with a hard error. Use `widget: datetime, type: date` for date-only fields (no time component). For datetime fields, use `widget: datetime` directly (no `type:` needed).
 - **Slugified upload filenames**: not Sveltia's default. Verify the relevant Sveltia option (search the docs for filename/slugification settings) before relying on slugified names landing in `assets/images/`.
 - **Navigation URL select options are hardcoded**: if site URLs change (new permalinks), the `options:` lists in the navigation collection need manual updating.
-- **Local FSA-API mode**: enabled via the Account menu in the deployed admin (`http://localhost:4000/admin/` while running `bundle exec jekyll serve`). Chromium-only. Local mode does NOT exercise PAT auth, the manual `cms-staging` → `main` publication PR, the squash-merge step, or the deploy pipeline — those all need the live admin against the deployed site.
+- **Local FSA-API mode**: enabled via the Account menu in the deployed admin (`http://localhost:4000/admin/` while running `bundle exec jekyll serve`). Chromium-only. Local mode does NOT exercise PAT auth, the "Publish CMS edits" workflow (neither the Publish Changes button's `repository_dispatch` nor the squash-merge), or the deploy pipeline — those all need the live admin against the deployed site.
 
 ## Future enhancements
 


### PR DESCRIPTION
Reorganize and brand the Sveltia admin to match the community manager's expectations (modeled on the UvA Bloomreach CMS he knows):

- Sidebar reordered around daily work: Events and News first, then a divider, then the site-section editors (Community, About D3I, Prepare a Study).
- Events list grouped by year by default (the Bloomreach year-folder equivalent), date-descending sort, preset filters per event type, human date in entry summaries; external_url moved up the form.
- News list gets image thumbnails (grid view), date-descending sort, optional year grouping.
- New page editors for the Events and Symposia archive pages (parity with the Courses page editor); hidden defaults mirror the live frontmatter exactly.
- Branding: app_title + logo (replaces deprecated logo_url); admin page gets favicon and matching title.
- Preview pane styled like the site via CMS.registerPreviewStyle and a new admin/preview.css; preview disabled on YAML data-list editors.
- One-click publish from inside the CMS: backend.skip_ci surfaces the Publish Changes button, whose repository_dispatch event (sveltia-cms-publish) now triggers the existing publish workflow. Publishing remains fully manual.
- Docs updated: manager guide (new sidebar, Publish Changes button) and maintainer notes (publish flow, appearance/view config).