### PR TITLE
feat(cms): complete page coverage and editor polish

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -80,6 +80,13 @@ collections:
     slug: "{{fields.date | date('YYYY')}}-{{slug}}"
     summary: "{{title}} — {{date | date('D MMM YYYY')}}"
     thumbnail: false
+    # Powers "View on Live Site" in the editor's ⋯ menu (resolved against
+    # site_url, i.e. staging). :path in the Jekyll permalink is the filename.
+    preview_path: "/community/events/{{filename}}/"
+    # Images inserted into event bodies land here instead of the global
+    # assets/images root.
+    media_folder: /assets/images/events
+    public_folder: /assets/images/events
     sortable_fields:
       fields: [date, title]
       default:
@@ -191,6 +198,13 @@ collections:
     slug: "{{fields.date | date('YYYY-MM-DD')}}-{{slug}}"
     summary: "{{title}} — {{date | date('D MMM YYYY')}}"
     thumbnail: image
+    # Powers "View on Live Site" in the editor's ⋯ menu (resolved against
+    # site_url, i.e. staging). :path in the Jekyll permalink is the filename.
+    preview_path: "/news/{{filename}}/"
+    # Collection-level default so images inserted into news bodies land in
+    # the same folder the Image field already uses.
+    media_folder: /assets/images/news
+    public_folder: /assets/images/news
     sortable_fields:
       fields: [date, title]
       default:
@@ -223,6 +237,46 @@ collections:
       - { name: layout, widget: hidden, default: "page" }
       - { name: body, label: "Full news item content (markdown)", widget: markdown, required: false }
 
+  # ──────────────── News page (file collection) ───────────────────────────
+  # The /news/ page itself — intro prose and contact block. A mini file
+  # collection because a folder collection (News above) cannot also hold
+  # an individual file editor.
+  - name: news_page
+    label: "News page"
+    icon: article
+    description: "The intro prose and contact block at /news/. News items themselves are edited in the News collection above."
+    files:
+      - file: _pages/news/index.md
+        name: news_index
+        label: "News page"
+        icon: article
+        description: "The intro prose at /news/. News items themselves are edited in the News collection."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: body
+            label: "Intro prose (markdown)"
+            widget: markdown
+            hint: "Short prose shown above the news list."
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: intro, label: "Intro text (optional)", widget: string, required: false }
+              - name: bullets
+                label: "Bullet points (optional)"
+                widget: list
+                required: false
+                field: { name: bullet, widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: permalink, widget: hidden, default: "/news/" }
+          - { name: layout, widget: hidden, default: "page-news" }
+
   # ───────────── Site sections (page editors + data lists) ────────────────
   - divider: true
 
@@ -232,6 +286,73 @@ collections:
     icon: forum
     description: "Pages and data lists under Community (/community/)."
     files:
+
+      - { divider: true, label: "Section landing page" }
+      - file: _pages/community/index.md
+        name: community_hub
+        label: "Community landing page"
+        icon: home
+        description: "The section landing page at /community/ — hero text, destination cards, optional highlight, and contact block."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - name: hero
+            label: "Hero"
+            widget: object
+            collapsed: true
+            summary: "{{title}}"
+            comment: "The illustration and heading at the top of the landing page."
+            fields:
+              - name: image
+                label: "Illustration"
+                widget: image
+                media_folder: /assets/images/hub
+                public_folder: /assets/images/hub
+                choose_url: false
+                max_file_size: 2097152
+                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+              - { name: image_alt, label: "Image alt text (required)", widget: string }
+              - { name: title, label: "Hero heading", widget: string }
+              - { name: subhead, label: "Hero subheading", widget: text }
+          - name: destinations
+            label: "Destination cards"
+            label_singular: "Card"
+            widget: list
+            summary: "{{title}}"
+            comment: "The cards linking to the pages of this section. Order here = order on the page."
+            fields:
+              - { name: title, label: "Card title", widget: string }
+              - { name: body, label: "Card text", widget: text }
+              - { name: link_url, label: "Link URL", widget: string, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (e.g. 'See all events →')", widget: string }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
+          # Hub contact blocks are heading + email only — no intro/bullets
+          # in the page frontmatter, so none exposed here (lossless saves).
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: hub_section, widget: hidden, default: "community" }
+          - { name: sidebar, widget: hidden, default: { nav: "community" } }
+          - { name: permalink, widget: hidden, default: "/community/" }
+          - { name: layout, widget: hidden, default: "hub-directory" }
 
       - { divider: true, label: "Events page" }
       - file: _pages/community/events/index.md
@@ -330,6 +451,23 @@ collections:
           - { name: toc, widget: hidden, default: false }
           - { name: permalink, widget: hidden, default: "/community/courses/" }
           - { name: layout, widget: hidden, default: "page-archive-stacked" }
+
+      - file: _pages/community/courses/materials.md
+        name: course_materials_page
+        label: "Course materials page"
+        icon: menu_book
+        description: "The data donation tutorial at /community/courses/materials — organizers, rationale, format, and downloadable materials."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: body
+            label: "Page content (markdown)"
+            widget: markdown
+            hint: "The full tutorial page: organizers, topic, rationale, format, and the materials list."
+          - { name: toc, widget: hidden, default: false }
+          - { name: sidebar, widget: hidden, default: { nav: "community" } }
+          - { name: permalink, widget: hidden, default: "/community/courses/materials" }
+          - { name: layout, widget: hidden, default: "page" }
 
       - { divider: true, label: "Symposia" }
       - file: _pages/community/symposia/index.md
@@ -569,6 +707,73 @@ collections:
     description: "Pages and data lists under About D3I (/about-d3i/)."
     files:
 
+      - { divider: true, label: "Section landing page" }
+      - file: _pages/about-d3i/index.md
+        name: about_d3i_hub
+        label: "About D3I landing page"
+        icon: home
+        description: "The section landing page at /about-d3i/ — hero text, destination cards, optional highlight, and contact block."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - name: hero
+            label: "Hero"
+            widget: object
+            collapsed: true
+            summary: "{{title}}"
+            comment: "The illustration and heading at the top of the landing page."
+            fields:
+              - name: image
+                label: "Illustration"
+                widget: image
+                media_folder: /assets/images/hub
+                public_folder: /assets/images/hub
+                choose_url: false
+                max_file_size: 2097152
+                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+              - { name: image_alt, label: "Image alt text (required)", widget: string }
+              - { name: title, label: "Hero heading", widget: string }
+              - { name: subhead, label: "Hero subheading", widget: text }
+          - name: destinations
+            label: "Destination cards"
+            label_singular: "Card"
+            widget: list
+            summary: "{{title}}"
+            comment: "The cards linking to the pages of this section. Order here = order on the page."
+            fields:
+              - { name: title, label: "Card title", widget: string }
+              - { name: body, label: "Card text", widget: text }
+              - { name: link_url, label: "Link URL", widget: string, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (e.g. 'Meet the team →')", widget: string }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
+          # Hub contact blocks are heading + email only — no intro/bullets
+          # in the page frontmatter, so none exposed here (lossless saves).
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: hub_section, widget: hidden, default: "about-d3i" }
+          - { name: sidebar, widget: hidden, default: { nav: "about-d3i" } }
+          - { name: permalink, widget: hidden, default: "/about-d3i/" }
+          - { name: layout, widget: hidden, default: "hub-directory" }
+
       - { divider: true, label: "Team" }
       - file: _pages/about-d3i/team.md
         name: team_page
@@ -578,6 +783,19 @@ collections:
         fields:
           - { name: title, label: "Page title", widget: string }
           - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
           - name: body
             label: "Intro prose (markdown)"
             widget: markdown
@@ -667,6 +885,19 @@ collections:
         fields:
           - { name: title, label: "Page title", widget: string }
           - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
           - name: body
             label: "Intro prose (markdown)"
             widget: markdown
@@ -720,6 +951,19 @@ collections:
         fields:
           - { name: title, label: "Page title", widget: string }
           - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
           - name: body
             label: "Intro prose (markdown)"
             widget: markdown
@@ -776,6 +1020,19 @@ collections:
         fields:
           - { name: title, label: "Page title", widget: string }
           - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
           - name: body
             label: "Intro prose (markdown — optional)"
             widget: markdown
@@ -832,6 +1089,19 @@ collections:
         fields:
           - { name: title, label: "Page title", widget: string }
           - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
           - name: body
             label: "Page body (markdown)"
             widget: markdown
@@ -932,6 +1202,87 @@ collections:
     description: "Pages and data lists under Prepare a Study (/prepare-a-study/)."
     files:
 
+      - { divider: true, label: "Section landing page" }
+      - file: _pages/prepare-a-study/index.md
+        name: prepare_a_study_hub
+        label: "Prepare a Study landing page"
+        icon: home
+        description: "The section landing page at /prepare-a-study/ — hero text, the three journey steps, optional highlight, and contact block."
+        fields:
+          - { name: title, label: "Page title", widget: string }
+          - name: hero
+            label: "Hero"
+            widget: object
+            collapsed: true
+            summary: "{{title}}"
+            comment: "The illustration and heading at the top of the landing page."
+            fields:
+              - name: image
+                label: "Illustration"
+                widget: image
+                media_folder: /assets/images/hub
+                public_folder: /assets/images/hub
+                choose_url: false
+                max_file_size: 2097152
+                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+              - { name: image_alt, label: "Image alt text (required)", widget: string }
+              - { name: title, label: "Hero heading", widget: string }
+              - { name: subhead, label: "Hero subheading", widget: text }
+          - name: movements
+            label: "Journey steps"
+            label_singular: "Step"
+            widget: list
+            summary: "{{title}}"
+            comment: "The image+text step blocks on the landing page. Order here = order on the page."
+            fields:
+              - { name: title, label: "Step title", widget: string }
+              - name: image
+                label: "Illustration"
+                widget: image
+                media_folder: /assets/images/hub
+                public_folder: /assets/images/hub
+                choose_url: false
+                max_file_size: 2097152
+                accept: "image/jpeg,image/png,image/svg+xml,image/webp"
+              - { name: image_alt, label: "Image alt text (required)", widget: string }
+              - { name: body, label: "Step text", widget: text }
+              - name: link
+                label: "Link"
+                widget: object
+                summary: "{{text}}"
+                fields:
+                  - { name: url, label: "URL", widget: string, comment: "Internal path (/...) or external URL (https://...). Both work." }
+                  - { name: text, label: "Link text", widget: string }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
+          # Hub contact blocks are heading + email only — no intro/bullets
+          # in the page frontmatter, so none exposed here (lossless saves).
+          - name: contact
+            label: "Contact CTA"
+            widget: object
+            collapsed: true
+            summary: "{{lead}}"
+            comment: "Renders as the contact CTA block at the bottom of the page."
+            fields:
+              - { name: lead, label: "Heading", widget: string }
+              - { name: email, label: "Email address", widget: string, type: email }
+              - { name: subject, label: "Email subject", widget: string }
+          - { name: hub_section, widget: hidden, default: "prepare-a-study" }
+          - { name: sidebar, widget: hidden, default: { nav: "prepare-a-study" } }
+          - { name: permalink, widget: hidden, default: "/prepare-a-study/" }
+          - { name: layout, widget: hidden, default: "hub-journey" }
+
       - { divider: true, label: "Completed projects" }
       - file: _pages/prepare-a-study/completed-projects.md
         name: completed_projects_page
@@ -941,6 +1292,19 @@ collections:
         fields:
           - { name: title, label: "Page title", widget: string }
           - { name: excerpt, label: "Page blurb", widget: string, maxlength: 200, comment: "Short one-line description (15-30 words). Used on landing pages that list this page, and in social-sharing previews." }
+          - name: postit
+            label: "Highlight (optional)"
+            widget: object
+            required: false
+            collapsed: true
+            summary: "{{title}}"
+            comment: "Optional time-sensitive highlight box rendered at the top of the page. Use sparingly — for things like urgent calls, position papers, or deadlines. Leave the checkbox unchecked when not in use."
+            fields:
+              - { name: eyebrow, label: "Eyebrow text", widget: string, required: false, default: "Updates", maxlength: 20 }
+              - { name: title, label: "Heading", widget: string, maxlength: 80 }
+              - { name: body, label: "Body", widget: text, maxlength: 200 }
+              - { name: link_url, label: "Link URL (optional)", widget: string, required: false, comment: "Internal path (/...) or external URL (https://...). Both work." }
+              - { name: link_text, label: "Link text (optional)", widget: string, required: false, maxlength: 30 }
           - name: body
             label: "Intro prose (markdown)"
             widget: markdown

--- a/cms/community-manager-guide.md
+++ b/cms/community-manager-guide.md
@@ -42,11 +42,17 @@ The left sidebar puts your day-to-day work at the top, with the site-section edi
 
 - **Events** — create new event pages (symposia, courses, workshops, and more); edit existing ones. The list is grouped by year (like folders), newest first. Use the filter icon above the list to show only one event type. Each entry produces its own page on the site and is listed on `/community/events/`; the Courses and Symposia pages automatically show the entries of the matching type.
 - **News** — create news items, newest first; switch to grid view to see image thumbnails. Each item appears on `/news/` and, while fresh (under ~3 months old), in the homepage "Latest news" strip.
-- **Community** — page editors and data lists for `/community/` (Events page, Courses page, Symposia page, Networks, Newsletter).
-- **About D3I** — page editors and data lists for `/about-d3i/` (Team, Advisory board, Funding, Partners, Impact and adoption).
-- **Prepare a Study** — page editor and data list for the Completed projects page.
+- **News page** — the intro text and contact block of the `/news/` page itself.
+- **Community** — page editors and data lists for `/community/` (the section landing page, Events page, Courses page + course materials, Symposia page, Networks, Newsletter).
+- **About D3I** — page editors and data lists for `/about-d3i/` (the section landing page, Team, Advisory board, Funding, Partners, Impact and adoption).
+- **Prepare a Study** — the section landing page and the Completed projects page with its data list.
 
 Within each section, page editors are paired with their supporting data list (e.g. "Team page" sits next to "Team members"). Edit the page when you want to change the prose; edit the data list when you want to add, remove, or reorder items shown on the page. The Events, Courses, and Symposia pages are the exception: their intro prose is a page editor under Community, while the events listed on them come from the Events collection at the top of the sidebar.
+
+Two extras worth knowing:
+
+- **Every page editor has a "Highlight" field** — an optional yellow note box rendered at the top of that page, for time-sensitive things like deadlines or announcements. Tick the checkbox to use it, untick to remove it.
+- **"View on Live Site"** — when editing an event or news item, the ⋯ menu (top right) opens that entry's page on the staging site, so you can see the published version next to your edits.
 
 ## Common tasks
 
@@ -63,6 +69,14 @@ This stores your edit on the `cms-staging` branch — it's saved, but not yet vi
 
 1. Dashboard → About D3I → Team page.
 2. Edit the **Intro prose** markdown field.
+3. Click **Save**.
+
+### Update a section landing page
+
+The landing pages of Community, About D3I, and Prepare a Study (the pages with the big cards) are each the first entry in their section.
+
+1. Dashboard → e.g. Community → **Community landing page**.
+2. Edit the hero text, or open **Destination cards** to change the card texts, links, or their order (drag to reorder).
 3. Click **Save**.
 
 ### Add a new event (symposium, course, workshop, …)

--- a/cms/maintainer-notes.md
+++ b/cms/maintainer-notes.md
@@ -38,6 +38,8 @@ How the admin look-and-feel is configured (all in `admin/config.yml` unless note
 - **Sidebar order**: collections are listed in manager-task order — Events and News (entry collections) first, then a top-level `- divider: true`, then the site-section file collections. Folder collections still cannot nest inside file collections, hence Events/News at top level.
 - **Entry-list views (Events)**: `sortable_fields` with a `default` of date-descending; `view_groups` grouping by year (regex `\d{4}` on `date`, `default: year`) to mirror the Bloomreach year-folder mental model; `view_filters` presets per `event_type`. Users can override sort/group/filter per-session via the toolbar; the config only sets defaults.
 - **Entry-list views (News)**: `thumbnail: image` (grid view shows the news image), date-descending default sort, optional year grouping (no default).
+- **"View on Live Site"** (the ⋯ menu in the entry editor): needs `preview_path` on the collection because Sveltia can't infer Jekyll permalinks — set to the permalink pattern with `{{filename}}` standing in for `:path` (see the Events and News collections). Resolves against `site_url`, i.e. staging. Entry collections only; file-collection page editors have no per-file equivalent.
+- **Body-image tidiness**: Events and News set collection-level `media_folder`/`public_folder` so images inserted into entry bodies land in `/assets/images/events` and `/assets/images/news` rather than the global root.
 - **Preview pane**: `admin/index.html` registers `admin/preview.css` via `CMS.registerPreviewStyle()` so entry previews use site typography (self-contained `@font-face` for the self-hosted Nunito fonts plus tokens copied from `_sass/_variables.scss` — keep in sync by hand). Data-list file editors set `editor: { preview: false }` because a preview of a raw YAML list is noise.
 
 ## Why PATs instead of OAuth (background)
@@ -120,9 +122,20 @@ Template for a list-of-records data file:
 For a page with known layout and frontmatter structure:
 
 1. Identify which frontmatter keys the layout reads (title, sidebar, etc.).
-2. Add an entry under the `pages` collection in `admin/config.yml`.
-3. Use `widget: hidden` for all structural keys (layout, permalink, redirect_from, sidebar.nav, etc.).
-4. Expose editable content (title, body, contact blocks) with appropriate widgets.
+2. Add a file entry to the page's section collection in `admin/config.yml` (Community, About D3I, Prepare a Study), under the appropriate divider.
+3. Use `widget: hidden` for all structural keys (layout, permalink, redirect_from, sidebar.nav, etc.), mirroring the file's live frontmatter **exactly** — a no-op save in the CMS must produce no git diff.
+4. Expose editable content (title, body, contact blocks) with appropriate widgets. Only model optional sub-fields the file actually has (e.g. hub contact blocks are lead/email/subject only): modelling absent optional strings makes saves write `key: ''` noise.
+
+## Deliberately not in the CMS
+
+Pages left out on purpose — don't add editors for these without addressing the stated reason:
+
+- **Homepage** (`index.md`): awaiting the external homepage redesign; expose it once the new structure lands. (Its frontmatter is otherwise fully mappable — postit, movements, hero.)
+- **`_pages/data-donation.md`**: the body embeds raw `<iframe>` video embeds, which the CMS rich-text editor can mangle on save.
+- **`_pages/prepare-a-study/study-design.md`**: body uses `notice--warning`/`notice--success` HTML divs — same mangling risk.
+- **`_pages/community/open-letter.md` / `omnibus-letter.md`**: the open letter contains a Liquid variable (`{{ site.open_letter_url }}`) and kramdown attribute syntax; the omnibus letter uses markdown footnotes. Both are signed position documents that shouldn't be casually editable anyway.
+- **Software section** (`_pages/software/*`): developer-owned technical content (script builder, install flows).
+- **Navigation** (`_data/navigation.yml`): developer-owned; URL changes require coordinated permalink/redirect work.
 
 ## Known CMS constraints
 


### PR DESCRIPTION
Round out the page-editing experience so capabilities are uniform and the manager can reach every page he plausibly owns:

- Section landing pages (Community, About D3I, Prepare a Study) get editors: hero text, destination cards / journey steps, optional highlight, contact block. Hidden defaults mirror live frontmatter; hub contact blocks expose only the keys the files actually have.
- New editors for the course materials tutorial page and the /news/ page intro (mini file collection below News).
- The optional Highlight (postit) field is now on every page editor — previously only 4 of 10 had it, though the layout supports it everywhere.
- Events and News get preview_path so "View on Live Site" in the entry editor opens the right staging URL, plus collection-level media folders so body images land in /assets/images/{events,news}.
- Maintainer notes: new "Deliberately not in the CMS" section (homepage pending redesign; iframe/HTML/Liquid-bearing pages the rich-text editor would mangle; software section; navigation), View-on-Live-Site wiring, and a corrected "Adding a new page" recipe (the old text referenced a nonexistent pages collection).
- Manager guide: landing-page task, Highlight and View-on-Live-Site notes, updated sidebar description.