### PR TITLE
Feat/carousel news scheduling

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -17,8 +17,15 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Manual deploys keep the protected `production` environment (required
+    # reviewer). Scheduled rebuilds use the unprotected `production-scheduled`
+    # environment so the daily run isn't blocked waiting for approval — safe
+    # because it only ever redeploys the already-approved `production` branch.
+    # NOTE: `production-scheduled` must exist with NO required reviewers, and
+    # the NETLIFY_* secrets must be reachable from it (repo-level secrets, or
+    # add them to that environment too). See cms/maintainer-notes.md.
     environment:
-      name: production
+      name: ${{ github.event_name == 'schedule' && 'production-scheduled' || 'production' }}
       url: https://datadonation.eu
     outputs:
       sha: ${{ steps.rev.outputs.sha }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,6 +2,13 @@ name: Deploy to Netlify (production)
 
 on:
   workflow_dispatch:
+  # Daily rebuild so future-dated ("scheduled") news surfaces on the day
+  # it is due: the build clock (site.time) advances even when no commits
+  # change, and the news filters drop items dated after build time.
+  # Off-the-hour, low-traffic UTC slot — GitHub delays scheduled runs that
+  # land on the start of an hour, so we avoid :00.
+  schedule:
+    - cron: "7 4 * * *"
 
 concurrency:
   group: "deploy-production"
@@ -13,9 +20,22 @@ jobs:
     environment:
       name: production
       url: https://datadonation.eu
+    outputs:
+      sha: ${{ steps.rev.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Scheduled runs redeploy only the last manually-approved snapshot
+          # (the `production` branch); manual runs promote the triggering ref
+          # (main), exactly as before. This keeps un-promoted main work off
+          # production even though the rebuild is now automated.
+          ref: ${{ github.event_name == 'schedule' && 'production' || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve deployed commit
+        id: rev
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -34,7 +54,30 @@ jobs:
           publish-dir: './_site'
           production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deployed from GitHub Actions - ${{ github.sha }}"
+          deploy-message: "Deployed from GitHub Actions - ${{ steps.rev.outputs.sha }} (${{ github.event_name }})"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+  # A manual production deploy doubles as the "promote" step: record the
+  # commit just shipped on the `production` branch, so the scheduled rebuild
+  # always redeploys this exact approved snapshot. Skipped on scheduled
+  # runs — those introduce no new content to approve.
+  record-snapshot:
+    needs: deploy
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Move production branch to the deployed commit
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.deploy.outputs.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${REPO}/git/refs/heads/production" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/production" -f sha="${SHA}" -F force=true
+          else
+            gh api -X POST "repos/${REPO}/git/refs" -f ref="refs/heads/production" -f sha="${SHA}"
+          fi

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,17 +15,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  # Manual promote: main HEAD → production, gated by the `production`
+  # environment's required reviewer. This is the only path that ships new
+  # content to the live site.
+  deploy-manual:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # Manual deploys keep the protected `production` environment (required
-    # reviewer). Scheduled rebuilds use the unprotected `production-scheduled`
-    # environment so the daily run isn't blocked waiting for approval — safe
-    # because it only ever redeploys the already-approved `production` branch.
-    # NOTE: `production-scheduled` must exist with NO required reviewers, and
-    # the NETLIFY_* secrets must be reachable from it (repo-level secrets, or
-    # add them to that environment too). See cms/maintainer-notes.md.
     environment:
-      name: ${{ github.event_name == 'schedule' && 'production-scheduled' || 'production' }}
+      name: production
       url: https://datadonation.eu
     outputs:
       sha: ${{ steps.rev.outputs.sha }}
@@ -33,11 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Scheduled runs redeploy only the last manually-approved snapshot
-          # (the `production` branch); manual runs promote the triggering ref
-          # (main), exactly as before. This keeps un-promoted main work off
-          # production even though the rebuild is now automated.
-          ref: ${{ github.event_name == 'schedule' && 'production' || github.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Resolve deployed commit
@@ -61,18 +54,18 @@ jobs:
           publish-dir: './_site'
           production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deployed from GitHub Actions - ${{ steps.rev.outputs.sha }} (${{ github.event_name }})"
+          deploy-message: "Manual deploy - ${{ steps.rev.outputs.sha }}"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
-  # A manual production deploy doubles as the "promote" step: record the
-  # commit just shipped on the `production` branch, so the scheduled rebuild
-  # always redeploys this exact approved snapshot. Skipped on scheduled
-  # runs — those introduce no new content to approve.
+  # The manual deploy doubles as the "promote" step: record the commit just
+  # shipped on the `production` branch so the scheduled job below redeploys
+  # exactly this approved snapshot. Separate job so the deploy job keeps its
+  # default token permissions (the Netlify action needs them); only this one
+  # is elevated to write a ref.
   record-snapshot:
-    needs: deploy
-    if: github.event_name == 'workflow_dispatch'
+    needs: deploy-manual
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -80,7 +73,7 @@ jobs:
       - name: Move production branch to the deployed commit
         env:
           REPO: ${{ github.repository }}
-          SHA: ${{ needs.deploy.outputs.sha }}
+          SHA: ${{ needs.deploy-manual.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh api "repos/${REPO}/git/refs/heads/production" >/dev/null 2>&1; then
@@ -88,3 +81,40 @@ jobs:
           else
             gh api -X POST "repos/${REPO}/git/refs" -f ref="refs/heads/production" -f sha="${SHA}"
           fi
+
+  # Scheduled rebuild: redeploys the already-approved `production` branch
+  # (never main HEAD), so it needs no approval — it runs with NO environment
+  # and reads the repository-level NETLIFY_* secrets. This only refreshes the
+  # build clock so future-dated news/events surface on their due date; it
+  # never ships un-promoted main work.
+  deploy-scheduled:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout production branch
+        uses: actions/checkout@v4
+        with:
+          ref: production
+          fetch-depth: 0
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: './_site'
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Scheduled rebuild - production branch"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/_includes/news-strip.html
+++ b/_includes/news-strip.html
@@ -11,7 +11,8 @@
 {% assign recent_news = "" | split: "" %}
 {% for item in sorted_news %}
   {% assign item_epoch = item.date | date: "%s" | plus: 0 %}
-  {% if item_epoch >= freshness_cutoff and recent_news.size < 3 %}
+  {% comment %} Skip future-dated items (scheduled news) and anything past the 90-day window. {% endcomment %}
+  {% if item_epoch <= now_epoch and item_epoch >= freshness_cutoff and recent_news.size < 3 %}
     {% assign recent_news = recent_news | push: item %}
   {% endif %}
 {% endfor %}

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -40,34 +40,55 @@ layout: site-shell
 </section>
 
 {% comment %}
-  Movements carousel: the movements front matter rendered as a manual
-  carousel — one slide at a time, navigated by arrows, dots, swipe, or
-  arrow keys. Progressive enhancement: without JS the slides stack and
-  stay readable; homepage-carousel.js adds the `is-enhanced` class that
-  switches the CSS into single-slide mode and wires up the controls.
+  Movements carousel ("Carousel B" / peek cards from the design handoff):
+  one focused card centred with neighbours peeking behind a white edge-fade.
+  Each card pairs a tinted illustration panel with text in the item's brand
+  accent. Progressive enhancement — without JS the slides stack into plain
+  full-width cards; homepage-carousel.js adds the `is-enhanced` class that
+  switches on the peek layout, sizing, and controls (arrows/dots/swipe/keys).
 {% endcomment %}
 <section class="homepage-stops">
   {% if page.movements %}
-    <div class="homepage-carousel" data-carousel>
-      <div class="homepage-carousel__viewport">
-        <div class="homepage-carousel__track" data-carousel-track>
+    <div class="movements-carousel" data-carousel tabindex="0"
+         aria-roledescription="carousel" aria-label="Explore datadonation.eu">
+      <div class="movements-carousel__viewport">
+        <div class="movements-carousel__track" data-carousel-track>
           {% for movement in page.movements %}
-            <article class="homepage-stop" data-carousel-slide>
-              <div class="homepage-stop__figure">
-                <img src="{{ movement.image | relative_url }}" alt="{{ movement.image_alt | default: '' }}">
-              </div>
-              <h2 class="homepage-stop__heading">{{ movement.heading }}</h2>
-              <p class="homepage-stop__body">{{ movement.body }}</p>
-              {% if movement.link %}
-                <a class="homepage-stop__link" href="{{ movement.link.url | relative_url }}">{{ movement.link.text }}&nbsp;→</a>
-              {% endif %}
-            </article>
+            <div class="movements-carousel__slide" data-carousel-slide data-accent="{{ movement.accent }}">
+              <article class="movement-card">
+                <div class="movement-card__figure" style="background: {{ movement.tint }};">
+                  <img src="{{ movement.image | relative_url }}" alt="{{ movement.image_alt | default: '' }}">
+                </div>
+                <div class="movement-card__text">
+                  {% if movement.eyebrow %}
+                    <span class="movement-card__eyebrow" style="color: {{ movement.accent }};">{{ movement.eyebrow }}</span>
+                  {% endif %}
+                  <h2 class="movement-card__heading">{{ movement.heading }}</h2>
+                  <p class="movement-card__body">{{ movement.body }}</p>
+                  {% if movement.link %}
+                    <a class="movement-card__link" style="color: {{ movement.accent }};" href="{{ movement.link.url | relative_url }}">{{ movement.link.text }}&nbsp;→</a>
+                  {% endif %}
+                </div>
+              </article>
+            </div>
           {% endfor %}
         </div>
       </div>
-      <button class="homepage-carousel__nav homepage-carousel__nav--prev" type="button" data-carousel-prev aria-label="Previous">‹</button>
-      <button class="homepage-carousel__nav homepage-carousel__nav--next" type="button" data-carousel-next aria-label="Next">›</button>
-      <div class="homepage-carousel__dots" data-carousel-dots></div>
+
+      {% comment %} Edge fades keep focus on the centred card (wide screens). {% endcomment %}
+      <div class="movements-carousel__fade movements-carousel__fade--left" aria-hidden="true"></div>
+      <div class="movements-carousel__fade movements-carousel__fade--right" aria-hidden="true"></div>
+
+      {% comment %} Gutter arrows on wide screens. {% endcomment %}
+      <button class="movements-carousel__arrow movements-carousel__arrow--gutter movements-carousel__arrow--prev" type="button" data-carousel-prev aria-label="Previous">‹</button>
+      <button class="movements-carousel__arrow movements-carousel__arrow--gutter movements-carousel__arrow--next" type="button" data-carousel-next aria-label="Next">›</button>
+
+      {% comment %} Control bar: dots always; arrows flank them on compact screens. {% endcomment %}
+      <div class="movements-carousel__controls">
+        <button class="movements-carousel__arrow movements-carousel__arrow--compact movements-carousel__arrow--prev" type="button" data-carousel-prev aria-label="Previous">‹</button>
+        <div class="movements-carousel__dots" data-carousel-dots></div>
+        <button class="movements-carousel__arrow movements-carousel__arrow--compact movements-carousel__arrow--next" type="button" data-carousel-next aria-label="Next">›</button>
+      </div>
     </div>
     <script src="{{ '/assets/js/homepage-carousel.js' | relative_url }}" defer></script>
   {% endif %}

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -40,30 +40,36 @@ layout: site-shell
 </section>
 
 {% comment %}
-  Route stops: the movements front matter rendered as three numbered
-  stops on a dashed route line that echoes the road above. Deliberately
-  not cards.
+  Movements carousel: the movements front matter rendered as a manual
+  carousel — one slide at a time, navigated by arrows, dots, swipe, or
+  arrow keys. Progressive enhancement: without JS the slides stack and
+  stay readable; homepage-carousel.js adds the `is-enhanced` class that
+  switches the CSS into single-slide mode and wires up the controls.
 {% endcomment %}
 <section class="homepage-stops">
   {% if page.movements %}
-    <div class="homepage-stops__track">
-      <div class="homepage-stops__line" aria-hidden="true"></div>
-      <div class="homepage-stops__grid">
-        {% for movement in page.movements %}
-          <article class="homepage-stop">
-            <span class="homepage-stop__marker" aria-hidden="true">{{ forloop.index }}</span>
-            <div class="homepage-stop__figure">
-              <img src="{{ movement.image | relative_url }}" alt="{{ movement.image_alt | default: '' }}">
-            </div>
-            <h2 class="homepage-stop__heading">{{ movement.heading }}</h2>
-            <p class="homepage-stop__body">{{ movement.body }}</p>
-            {% if movement.link %}
-              <a class="homepage-stop__link" href="{{ movement.link.url | relative_url }}">{{ movement.link.text }}&nbsp;→</a>
-            {% endif %}
-          </article>
-        {% endfor %}
+    <div class="homepage-carousel" data-carousel>
+      <div class="homepage-carousel__viewport">
+        <div class="homepage-carousel__track" data-carousel-track>
+          {% for movement in page.movements %}
+            <article class="homepage-stop" data-carousel-slide>
+              <div class="homepage-stop__figure">
+                <img src="{{ movement.image | relative_url }}" alt="{{ movement.image_alt | default: '' }}">
+              </div>
+              <h2 class="homepage-stop__heading">{{ movement.heading }}</h2>
+              <p class="homepage-stop__body">{{ movement.body }}</p>
+              {% if movement.link %}
+                <a class="homepage-stop__link" href="{{ movement.link.url | relative_url }}">{{ movement.link.text }}&nbsp;→</a>
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
       </div>
+      <button class="homepage-carousel__nav homepage-carousel__nav--prev" type="button" data-carousel-prev aria-label="Previous">‹</button>
+      <button class="homepage-carousel__nav homepage-carousel__nav--next" type="button" data-carousel-next aria-label="Next">›</button>
+      <div class="homepage-carousel__dots" data-carousel-dots></div>
     </div>
+    <script src="{{ '/assets/js/homepage-carousel.js' | relative_url }}" defer></script>
   {% endif %}
 
   <div class="homepage-outro">

--- a/_layouts/page-news.html
+++ b/_layouts/page-news.html
@@ -2,7 +2,20 @@
 layout: site-shell
 ---
 
-{% assign news_items = site.news | sort: "date" | reverse %}
+{% comment %}
+  Exclude future-dated items (scheduled news) so they only surface once
+  their date arrives. No upper-age cap here — the News tab keeps full
+  history, unlike the homepage strip's 90-day window.
+{% endcomment %}
+{% assign now_epoch = site.time | date: "%s" | plus: 0 %}
+{% assign sorted_news = site.news | sort: "date" | reverse %}
+{% assign news_items = "" | split: "" %}
+{% for item in sorted_news %}
+  {% assign item_epoch = item.date | date: "%s" | plus: 0 %}
+  {% if item_epoch <= now_epoch %}
+    {% assign news_items = news_items | push: item %}
+  {% endif %}
+{% endfor %}
 {% assign stripped_content = content | strip %}
 
 <article class="content-page">

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -166,10 +166,14 @@
 .homepage-road__sprite--cyclist   { left: 72%; bottom: 56px; width: 71px; }
 
 // ---------------------------------------------------------------------
-// Movements carousel: one slide visible at a time, navigated manually
-// (arrows, dots, swipe, arrow keys). Slides are rendered stacked so the
-// section works without JS; homepage-carousel.js adds the `is-enhanced`
-// class that switches to single-slide mode and reveals the controls.
+// Movements carousel — "Carousel B" (peek cards) from the design handoff.
+// One focused card centred, neighbours peeking behind a white edge-fade,
+// each pairing a tinted illustration panel with accent-coloured text.
+// Rendered as stacked full-width cards without JS; homepage-carousel.js
+// adds `is-enhanced` (peek layout + controls) and toggles `is-compact`
+// from a ResizeObserver, so the layout responds to its container width
+// rather than just the viewport. Per-item accent/tint come from inline
+// styles driven by the movements front matter.
 // ---------------------------------------------------------------------
 
 .homepage-stops {
@@ -180,151 +184,259 @@
   width: 100%;
 }
 
-.homepage-carousel {
+.movements-carousel {
   position: relative;
+  outline: none;
 }
 
-.homepage-carousel__track {
-  // No-JS fallback: stacked slides with breathing room between them.
+.movements-carousel__track {
+  // No-JS fallback: stacked full-width cards with breathing room.
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 1.5rem;
 }
 
-.homepage-stop {
-  display: flex;
-  flex-direction: column;
+.movements-carousel__slide {
+  display: flex; // let the card stretch to the slide height
+  box-sizing: border-box;
+}
+
+.movement-card {
+  flex: 1;
+  min-width: 0;
+  background: #ffffff;
+  border: 1px solid rgba(37, 42, 52, 0.10);
+  border-radius: 22px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 26px 50px -28px rgba(37, 42, 52, 0.30);
+  padding: 24px;
+  display: grid;
+  grid-template-columns: 1fr; // stacked by default; split when enhanced + wide
+  gap: 22px;
   align-items: center;
-  text-align: center;
 }
 
-.homepage-stop__figure {
+.movement-card__figure {
+  border-radius: 16px;
+  min-height: 150px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
-  height: 15rem;
-  margin-bottom: 1.5rem;
+  padding: 20px;
+  box-sizing: border-box;
 
   img {
-    max-height: 15rem;
-    max-width: 22rem;
+    display: block;
+    width: 100%;
+    max-height: 138px;
+    object-fit: contain;
   }
 }
 
-.homepage-stop__heading {
-  margin: 0 0 0.6rem;
-  font-family: "Nunito", $sans-serif;
-  font-size: 1.5rem;
+.movement-card__eyebrow {
+  display: inline-block;
+  font-family: "Nunito Sans", $sans-serif;
   font-weight: 800;
-  color: #252a34;
-  line-height: 1.25;
+  font-size: 0.72rem;
+  line-height: 1;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
 }
 
-.homepage-stop__body {
-  margin: 0 0 1.1rem;
-  padding: 0; // cancel the site's base `p` padding — not in the design
-  max-width: 32rem;
-  font-size: 1.05rem;
-  line-height: 1.6;
-  color: $text-color;
-}
-
-.homepage-stop__link {
-  white-space: nowrap;
+.movement-card__heading {
+  margin: 0 0 14px;
   font-family: "Nunito", $sans-serif;
-  font-weight: 700;
-  font-size: 1rem;
-  color: $accent-secondary;
+  font-weight: 800;
+  font-size: 1.7rem;
+  line-height: 1.14;
+  letter-spacing: -0.01em;
+  color: #252a34;
+  text-wrap: balance;
+}
+
+.movement-card__body {
+  margin: 0 0 22px;
+  padding: 0; // cancel the site's base `p` padding — not in the design
+  font-size: 1.04rem;
+  line-height: 1.6;
+  color: #555a63;
+  text-wrap: pretty;
+}
+
+.movement-card__link {
+  font-family: "Nunito", $sans-serif;
+  font-weight: 800;
+  font-size: 1.02rem;
   text-decoration: none;
-  border-bottom: 1.5px solid transparent;
+  border-bottom: 2px solid transparent;
+  padding-bottom: 2px;
+  white-space: nowrap;
   transition: border-color 0.15s ease;
 
   &:hover, &:focus {
-    border-bottom-color: $accent-secondary;
+    border-bottom-color: currentColor; // matches the item's accent
   }
 }
 
-// Controls stay hidden until JS enhances the carousel.
-.homepage-carousel__nav,
-.homepage-carousel__dots {
+// Fades, arrows, and the control bar appear only once JS enhances.
+.movements-carousel__fade,
+.movements-carousel__arrow,
+.movements-carousel__controls {
   display: none;
 }
 
-.homepage-carousel.is-enhanced {
-  .homepage-carousel__viewport {
+// --- Enhanced (JS active): peek-card carousel ------------------------------
+
+.movements-carousel.is-enhanced {
+  .movements-carousel__viewport {
     overflow: hidden;
   }
 
-  .homepage-carousel__track {
+  .movements-carousel__track {
     flex-direction: row;
     gap: 0;
-    transition: transform 0.4s ease;
+    transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1);
+    will-change: transform;
   }
 
-  .homepage-stop {
-    flex: 0 0 100%;
-    min-width: 0;
-    padding: 0 0.5rem;
-    box-sizing: border-box;
+  .movements-carousel__slide {
+    flex: 0 0 var(--slide-basis, 72%);
+    padding: 12px 12px 16px;
   }
 
-  .homepage-carousel__nav {
+  // Wide cards: tinted illustration panel beside the text.
+  .movement-card {
+    grid-template-columns: 40% 1fr;
+    gap: 40px;
+    padding: 36px 42px;
+  }
+
+  .movement-card__figure {
+    min-height: 220px;
+
+    img {
+      max-height: 188px;
+    }
+  }
+
+  .movements-carousel__fade {
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--fade-w, 14%);
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .movements-carousel__fade--left {
+    left: 0;
+    background: linear-gradient(to right, #ffffff 12%, rgba(255, 255, 255, 0));
+  }
+
+  .movements-carousel__fade--right {
+    right: 0;
+    background: linear-gradient(to left, #ffffff 12%, rgba(255, 255, 255, 0));
+  }
+
+  // Gutter arrows on wide screens.
+  .movements-carousel__arrow--gutter {
     display: flex;
     align-items: center;
     justify-content: center;
     position: absolute;
-    top: 7.5rem; // centered on the 15rem figure
+    top: 50%;
     transform: translateY(-50%);
-    width: 2.75rem;
-    height: 2.75rem;
-    padding: 0;
-    border: 0;
+    width: 52px;
+    height: 52px;
     border-radius: 50%;
-    background: $accent-primary;
-    color: #ffffff;
+    border: 1px solid rgba(37, 42, 52, 0.08);
+    background: #ffffff;
+    color: $accent-primary;
     font-size: 1.6rem;
     line-height: 1;
     cursor: pointer;
-    transition: filter 0.15s ease, opacity 0.15s ease;
+    z-index: 3;
+    box-shadow: 0 8px 22px -8px rgba(37, 42, 52, 0.4);
+    transition: transform 0.15s ease;
 
     &:hover, &:focus {
-      filter: brightness(0.92);
+      transform: translateY(-50%) scale(1.08);
     }
   }
 
-  .homepage-carousel__nav--prev { left: 0; }
-  .homepage-carousel__nav--next { right: 0; }
+  .movements-carousel__arrow--gutter.movements-carousel__arrow--prev { left: 0; }
+  .movements-carousel__arrow--gutter.movements-carousel__arrow--next { right: 0; }
 
-  .homepage-carousel__dots {
+  .movements-carousel__controls {
     display: flex;
+    align-items: center;
     justify-content: center;
-    gap: 0.6rem;
-    margin-top: 1.75rem;
+    gap: 20px;
+    margin-top: 28px;
+  }
+
+  .movements-carousel__dots {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+  }
+
+  // --- Compact (narrow container): stack the card, arrows join the dots ---
+  &.is-compact {
+    .movement-card {
+      grid-template-columns: 1fr;
+      gap: 22px;
+      padding: 24px;
+    }
+
+    .movement-card__figure {
+      min-height: 150px;
+
+      img {
+        max-height: 138px;
+      }
+    }
+
+    .movements-carousel__arrow--gutter {
+      display: none;
+    }
+
+    .movements-carousel__arrow--compact {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 auto;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      border: 1px solid rgba(37, 42, 52, 0.12);
+      background: #ffffff;
+      color: $accent-primary;
+      font-size: 1.4rem;
+      line-height: 1;
+      cursor: pointer;
+    }
   }
 }
 
-.homepage-carousel__dot {
-  width: 0.7rem;
-  height: 0.7rem;
-  padding: 0;
+.movements-carousel__dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 6px;
   border: 0;
-  border-radius: 50%;
-  background: rgba(66, 114, 239, 0.3);
+  padding: 0;
+  background: #d4d7dd;
   cursor: pointer;
-  transition: background 0.15s ease, transform 0.15s ease;
-
-  &:hover, &:focus {
-    background: rgba(66, 114, 239, 0.55);
-  }
+  transition: all 0.3s ease;
 
   &.is-active {
-    background: $accent-primary;
-    transform: scale(1.15);
+    width: 32px; // pill; JS paints it in the active item's accent
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .homepage-carousel.is-enhanced .homepage-carousel__track {
+  .movements-carousel.is-enhanced .movements-carousel__track {
     transition: none;
   }
 }
@@ -378,18 +490,6 @@
     display: none;
   }
 
-  // Smaller illustration on phones; keep the nav arrows centered on it
-  .homepage-stop__figure {
-    height: 10rem;
-    margin-bottom: 1.25rem;
-
-    img {
-      max-height: 10rem;
-      max-width: 16rem;
-    }
-  }
-
-  .homepage-carousel.is-enhanced .homepage-carousel__nav {
-    top: 5rem;
-  }
+  // The carousel's own compact layout is container-driven (JS toggles
+  // `is-compact`), so it needs no viewport breakpoint here.
 }

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -166,8 +166,10 @@
 .homepage-road__sprite--cyclist   { left: 72%; bottom: 56px; width: 71px; }
 
 // ---------------------------------------------------------------------
-// Route stops: three numbered stops on a dashed route line that echoes
-// the road above. Deliberately not cards — no borders or backgrounds.
+// Movements carousel: one slide visible at a time, navigated manually
+// (arrows, dots, swipe, arrow keys). Slides are rendered stacked so the
+// section works without JS; homepage-carousel.js adds the `is-enhanced`
+// class that switches to single-slide mode and reveals the controls.
 // ---------------------------------------------------------------------
 
 .homepage-stops {
@@ -178,82 +180,60 @@
   width: 100%;
 }
 
-.homepage-stops__track {
+.homepage-carousel {
   position: relative;
 }
 
-.homepage-stops__line {
-  position: absolute;
-  top: 1.25rem;
-  left: 4%;
-  right: 4%;
-  border-top: 3px dashed rgba(66, 114, 239, 0.3);
-}
-
-.homepage-stops__grid {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0 3rem;
+.homepage-carousel__track {
+  // No-JS fallback: stacked slides with breathing room between them.
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
 }
 
 .homepage-stop {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-}
-
-.homepage-stop__marker {
-  display: flex;
   align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  background: $accent-primary;
-  color: #ffffff;
-  font-family: "Nunito", $sans-serif;
-  font-weight: 800;
-  font-size: 1.05rem;
-  box-shadow: 0 0 0 6px #ffffff; // punches a gap in the dashed line
-  margin-bottom: 1.3rem;
+  text-align: center;
 }
 
 .homepage-stop__figure {
   display: flex;
   align-items: flex-end;
-  height: 6.5rem;
-  margin-bottom: 1.1rem;
+  justify-content: center;
+  height: 15rem;
+  margin-bottom: 1.5rem;
 
   img {
-    max-height: 6.5rem;
-    max-width: 10rem;
+    max-height: 15rem;
+    max-width: 22rem;
   }
 }
 
 .homepage-stop__heading {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.6rem;
   font-family: "Nunito", $sans-serif;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   font-weight: 800;
   color: #252a34;
   line-height: 1.25;
 }
 
 .homepage-stop__body {
-  margin: 0 0 0.9rem;
+  margin: 0 0 1.1rem;
   padding: 0; // cancel the site's base `p` padding — not in the design
-  font-size: 0.97rem;
+  max-width: 32rem;
+  font-size: 1.05rem;
   line-height: 1.6;
   color: $text-color;
 }
 
 .homepage-stop__link {
-  margin-top: auto;
   white-space: nowrap;
   font-family: "Nunito", $sans-serif;
   font-weight: 700;
-  font-size: 0.97rem;
+  font-size: 1rem;
   color: $accent-secondary;
   text-decoration: none;
   border-bottom: 1.5px solid transparent;
@@ -261,6 +241,91 @@
 
   &:hover, &:focus {
     border-bottom-color: $accent-secondary;
+  }
+}
+
+// Controls stay hidden until JS enhances the carousel.
+.homepage-carousel__nav,
+.homepage-carousel__dots {
+  display: none;
+}
+
+.homepage-carousel.is-enhanced {
+  .homepage-carousel__viewport {
+    overflow: hidden;
+  }
+
+  .homepage-carousel__track {
+    flex-direction: row;
+    gap: 0;
+    transition: transform 0.4s ease;
+  }
+
+  .homepage-stop {
+    flex: 0 0 100%;
+    min-width: 0;
+    padding: 0 0.5rem;
+    box-sizing: border-box;
+  }
+
+  .homepage-carousel__nav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 7.5rem; // centered on the 15rem figure
+    transform: translateY(-50%);
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background: $accent-primary;
+    color: #ffffff;
+    font-size: 1.6rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: filter 0.15s ease, opacity 0.15s ease;
+
+    &:hover, &:focus {
+      filter: brightness(0.92);
+    }
+  }
+
+  .homepage-carousel__nav--prev { left: 0; }
+  .homepage-carousel__nav--next { right: 0; }
+
+  .homepage-carousel__dots {
+    display: flex;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-top: 1.75rem;
+  }
+}
+
+.homepage-carousel__dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(66, 114, 239, 0.3);
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+
+  &:hover, &:focus {
+    background: rgba(66, 114, 239, 0.55);
+  }
+
+  &.is-active {
+    background: $accent-primary;
+    transform: scale(1.15);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .homepage-carousel.is-enhanced .homepage-carousel__track {
+    transition: none;
   }
 }
 
@@ -301,17 +366,6 @@
   .homepage-hero__plane {
     display: none;
   }
-
-  // Stops stack vertically; the horizontal route line goes away
-  // (markers keep their white ring so the rhythm still reads)
-  .homepage-stops__line {
-    display: none;
-  }
-
-  .homepage-stops__grid {
-    grid-template-columns: 1fr;
-    gap: 2.5rem 0;
-  }
 }
 
 @media (max-width: $small) {
@@ -322,5 +376,20 @@
 
   .homepage-road__sprite {
     display: none;
+  }
+
+  // Smaller illustration on phones; keep the nav arrows centered on it
+  .homepage-stop__figure {
+    height: 10rem;
+    margin-bottom: 1.25rem;
+
+    img {
+      max-height: 10rem;
+      max-width: 16rem;
+    }
+  }
+
+  .homepage-carousel.is-enhanced .homepage-carousel__nav {
+    top: 5rem;
   }
 }

--- a/_sass/_pages.scss
+++ b/_sass/_pages.scss
@@ -64,6 +64,17 @@
   }
 }
 
+// On full-width pages (no sidebar) the grid is a single column, so the
+// main column must sit in column 1. Without this it inherits `grid-column: 2`
+// above, which spawns an empty implicit column on the left and jams the
+// content into a narrow auto-sized column on the right.
+.content-page__grid--full .content-page__main {
+  @media (min-width: $medium-wide) {
+    grid-column: 1;
+    grid-row: auto;
+  }
+}
+
 // ---------------------------------------------------------------------
 // Page intro (title + hero + excerpt)
 // ---------------------------------------------------------------------

--- a/assets/js/homepage-carousel.js
+++ b/assets/js/homepage-carousel.js
@@ -1,9 +1,13 @@
-// Homepage "movements" carousel. The slides are rendered stacked so the
-// section is usable without JS; this script enhances each [data-carousel]
-// into a single-slide-at-a-time carousel driven by prev/next buttons,
-// generated dots, horizontal swipe, and left/right arrow keys. No autoplay.
+// Homepage "movements" carousel — "Carousel B" (peek cards) from the design
+// handoff. One focused card is centred with its neighbours peeking at the
+// edges; the active card recolours the active dot with the item's accent.
+// The slides are rendered stacked so the section works without JS; this
+// script adds `is-enhanced` to switch on the peek layout and controls, and
+// toggles `is-compact` from a ResizeObserver so the layout responds to the
+// carousel's own width rather than just the viewport. No autoplay.
 (function () {
   var SWIPE_THRESHOLD = 40; // px of horizontal travel before a swipe counts
+  var COMPACT_MAX = 680; // container width (px) below which the card stacks
 
   function setup(carousel) {
     var track = carousel.querySelector("[data-carousel-track]");
@@ -12,18 +16,25 @@
     );
     if (!track || slides.length < 2) return; // nothing to navigate
 
-    var prevBtn = carousel.querySelector("[data-carousel-prev]");
-    var nextBtn = carousel.querySelector("[data-carousel-next]");
     var dotsWrap = carousel.querySelector("[data-carousel-dots]");
+    var prevBtns = carousel.querySelectorAll("[data-carousel-prev]");
+    var nextBtns = carousel.querySelectorAll("[data-carousel-next]");
+
     var index = 0;
+    var basis = 72; // slide width as % of the viewport (recomputed in measure)
+    var gutter = 14; // (100 - basis) / 2 — peek + fade width on each side
     var dots = [];
 
     if (dotsWrap) {
       slides.forEach(function (slide, i) {
         var dot = document.createElement("button");
         dot.type = "button";
-        dot.className = "homepage-carousel__dot";
-        dot.setAttribute("aria-label", "Go to slide " + (i + 1));
+        dot.className = "movements-carousel__dot";
+        var heading = slide.querySelector(".movement-card__heading");
+        dot.setAttribute(
+          "aria-label",
+          "Go to " + (heading ? heading.textContent.trim() : "slide " + (i + 1))
+        );
         dot.addEventListener("click", function () {
           go(i);
         });
@@ -32,56 +43,91 @@
       });
     }
 
-    function go(next) {
-      // Wrap around in both directions so the carousel loops continuously.
-      index = ((next % slides.length) + slides.length) % slides.length;
-      track.style.transform = "translateX(" + index * -100 + "%)";
+    function render() {
+      // Centre the active slide: shift left by the gutter, then by i slides.
+      track.style.transform =
+        "translateX(calc(" + gutter + "% - " + index * basis + "%))";
+
       slides.forEach(function (slide, i) {
-        var active = i === index;
-        slide.classList.toggle("is-active", active);
-        slide.setAttribute("aria-hidden", active ? "false" : "true");
+        slide.setAttribute("aria-hidden", i === index ? "false" : "true");
       });
+
+      var accent = slides[index].getAttribute("data-accent") || "";
       dots.forEach(function (dot, i) {
         var active = i === index;
         dot.classList.toggle("is-active", active);
-        dot.setAttribute("aria-current", active ? "true" : "false");
+        if (active) {
+          dot.setAttribute("aria-current", "true");
+          dot.style.background = accent; // pill takes the item's accent
+        } else {
+          dot.removeAttribute("aria-current");
+          dot.style.background = ""; // fall back to the neutral CSS colour
+        }
       });
     }
 
-    if (prevBtn) {
-      prevBtn.addEventListener("click", function () {
+    function go(n) {
+      var len = slides.length;
+      index = ((n % len) + len) % len; // wrap around in both directions
+      render();
+    }
+
+    function measure() {
+      var w = carousel.getBoundingClientRect().width;
+      if (!w) return;
+      var compact = w < COMPACT_MAX;
+      basis = compact ? 90 : 72;
+      gutter = (100 - basis) / 2;
+      carousel.classList.toggle("is-compact", compact);
+      carousel.style.setProperty("--slide-basis", basis + "%");
+      carousel.style.setProperty("--fade-w", gutter + "%");
+      render();
+    }
+
+    Array.prototype.forEach.call(prevBtns, function (btn) {
+      btn.addEventListener("click", function () {
         go(index - 1);
       });
-    }
-    if (nextBtn) {
-      nextBtn.addEventListener("click", function () {
+    });
+    Array.prototype.forEach.call(nextBtns, function (btn) {
+      btn.addEventListener("click", function () {
         go(index + 1);
       });
-    }
+    });
 
     carousel.addEventListener("keydown", function (e) {
-      if (e.key === "ArrowLeft") {
-        go(index - 1);
-      } else if (e.key === "ArrowRight") {
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
         go(index + 1);
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        go(index - 1);
       }
     });
 
-    // Pointer-based horizontal swipe (works for touch and mouse drag).
+    // Pointer-based horizontal swipe (touch and mouse drag).
     var startX = null;
     carousel.addEventListener("pointerdown", function (e) {
       startX = e.clientX;
     });
     carousel.addEventListener("pointerup", function (e) {
       if (startX === null) return;
-      var delta = e.clientX - startX;
+      var dx = e.clientX - startX;
       startX = null;
-      if (Math.abs(delta) < SWIPE_THRESHOLD) return;
-      go(delta < 0 ? index + 1 : index - 1);
+      if (dx <= -SWIPE_THRESHOLD) go(index + 1);
+      else if (dx >= SWIPE_THRESHOLD) go(index - 1);
     });
 
     carousel.classList.add("is-enhanced");
-    go(0);
+    measure();
+
+    if (window.ResizeObserver) {
+      new window.ResizeObserver(function () {
+        measure();
+      }).observe(carousel);
+    } else {
+      window.addEventListener("resize", measure);
+    }
   }
 
   function init() {

--- a/assets/js/homepage-carousel.js
+++ b/assets/js/homepage-carousel.js
@@ -1,0 +1,96 @@
+// Homepage "movements" carousel. The slides are rendered stacked so the
+// section is usable without JS; this script enhances each [data-carousel]
+// into a single-slide-at-a-time carousel driven by prev/next buttons,
+// generated dots, horizontal swipe, and left/right arrow keys. No autoplay.
+(function () {
+  var SWIPE_THRESHOLD = 40; // px of horizontal travel before a swipe counts
+
+  function setup(carousel) {
+    var track = carousel.querySelector("[data-carousel-track]");
+    var slides = Array.prototype.slice.call(
+      carousel.querySelectorAll("[data-carousel-slide]")
+    );
+    if (!track || slides.length < 2) return; // nothing to navigate
+
+    var prevBtn = carousel.querySelector("[data-carousel-prev]");
+    var nextBtn = carousel.querySelector("[data-carousel-next]");
+    var dotsWrap = carousel.querySelector("[data-carousel-dots]");
+    var index = 0;
+    var dots = [];
+
+    if (dotsWrap) {
+      slides.forEach(function (slide, i) {
+        var dot = document.createElement("button");
+        dot.type = "button";
+        dot.className = "homepage-carousel__dot";
+        dot.setAttribute("aria-label", "Go to slide " + (i + 1));
+        dot.addEventListener("click", function () {
+          go(i);
+        });
+        dotsWrap.appendChild(dot);
+        dots.push(dot);
+      });
+    }
+
+    function go(next) {
+      // Wrap around in both directions so the carousel loops continuously.
+      index = ((next % slides.length) + slides.length) % slides.length;
+      track.style.transform = "translateX(" + index * -100 + "%)";
+      slides.forEach(function (slide, i) {
+        var active = i === index;
+        slide.classList.toggle("is-active", active);
+        slide.setAttribute("aria-hidden", active ? "false" : "true");
+      });
+      dots.forEach(function (dot, i) {
+        var active = i === index;
+        dot.classList.toggle("is-active", active);
+        dot.setAttribute("aria-current", active ? "true" : "false");
+      });
+    }
+
+    if (prevBtn) {
+      prevBtn.addEventListener("click", function () {
+        go(index - 1);
+      });
+    }
+    if (nextBtn) {
+      nextBtn.addEventListener("click", function () {
+        go(index + 1);
+      });
+    }
+
+    carousel.addEventListener("keydown", function (e) {
+      if (e.key === "ArrowLeft") {
+        go(index - 1);
+      } else if (e.key === "ArrowRight") {
+        go(index + 1);
+      }
+    });
+
+    // Pointer-based horizontal swipe (works for touch and mouse drag).
+    var startX = null;
+    carousel.addEventListener("pointerdown", function (e) {
+      startX = e.clientX;
+    });
+    carousel.addEventListener("pointerup", function (e) {
+      if (startX === null) return;
+      var delta = e.clientX - startX;
+      startX = null;
+      if (Math.abs(delta) < SWIPE_THRESHOLD) return;
+      go(delta < 0 ? index + 1 : index - 1);
+    });
+
+    carousel.classList.add("is-enhanced");
+    go(0);
+  }
+
+  function init() {
+    document.querySelectorAll("[data-carousel]").forEach(setup);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/cms/community-manager-guide.md
+++ b/cms/community-manager-guide.md
@@ -98,6 +98,8 @@ The landing pages of Community, About D3I, and Prepare a Study (the pages with t
 
 News items appear on the News page immediately after publication. The homepage "Latest news" strip shows the three most recent items and automatically drops anything older than about 3 months.
 
+**Scheduling ahead:** if you give a news item a date in the **future**, it stays hidden until that day and then appears on its own — handy for announcements you want to prepare in advance. Publish it as usual (and let Danielle know it's a scheduled item so she promotes it to production before its date). To preview the wording before then, set today's date while drafting, since future-dated items are hidden on staging too.
+
 ## How "Save" works
 
 Every time you click **Save**, the CMS commits your edit to a behind-the-scenes branch called `cms-staging`. **The change is recorded but not yet visible on the live site.** This lets you make a series of edits in one sitting without each one immediately going live — useful for typo fixes, preview-and-revise cycles, or batches of related updates.
@@ -130,6 +132,8 @@ Red X = build failed. Email Danielle with a screenshot.
 ## Production (datadonation.eu)
 
 After staging looks good, Danielle approves the production deployment to push your changes to datadonation.eu. The deploy workflow waits for her approval — until she clicks Approve in GitHub Actions, datadonation.eu shows the previous version. Tell her when you're ready.
+
+Production also refreshes itself once a day from the last approved version. This never publishes new edits on its own — it only updates the date-sensitive bits, like making a scheduled (future-dated) news item appear on its day, or moving a finished event out of "upcoming." Anything new still waits for Danielle's approval.
 
 ## Three things to know
 

--- a/cms/maintainer-notes.md
+++ b/cms/maintainer-notes.md
@@ -30,6 +30,36 @@ The `cms-staging` branch must stay in sync with `main` to avoid merge conflicts 
 - **It surfaces a "Publish Changes" button in the CMS header.** Clicking it fires a `repository_dispatch` event of type `sveltia-cms-publish` against the default branch, which `.github/workflows/publish-cms-edits.yml` lists as a trigger alongside `workflow_dispatch`. So the manager publishes from inside the CMS; the Actions-tab "Run workflow" path remains as a fallback. Publishing stays fully manual either way — saves never auto-publish.
 - **Save commits to `cms-staging` get a `[skip ci]` message prefix** (deletions are exempted by Sveltia, by design). This is harmless here: no workflow builds off `cms-staging` pushes, and the publication squash-merge to `main` is performed with `GITHUB_TOKEN`, which never fires push-triggered workflows regardless of commit message — the publish workflow already compensates by dispatching the staging deploy and the branch reset explicitly. **Caveat**: if you ever merge `cms-staging` into `main` by hand (web UI or local), the squash commit body may inherit a `[skip ci]` line from a constituent commit and silently suppress push-triggered workflows (`deploy-staging`, `reset-cms-staging`); check for it before merging manually.
 
+## Deploy environments & the `production` branch
+
+Two environments, two workflows:
+
+- **Staging** — GitHub Pages at https://d3i-website.github.io/. `.github/workflows/deploy-staging.yml` auto-deploys on every push to `main` (and `workflow_dispatch`).
+- **Production** — Netlify at https://datadonation.eu/. `.github/workflows/deploy-production.yml`, via the `nwtgck/actions-netlify` action. Production is **gated** — a human triggers it, and the `production` GitHub Environment has a required-reviewer rule (Danielle) on manual runs.
+
+**The `production` branch is the last manually-approved live snapshot.** It's the source of truth for what production deploys, deliberately decoupled from `main` (which can hold staging-approved-but-not-yet-promoted work, including pending CMS publications). It was created at the commit that was live on Netlify at the time (`5895aa2`).
+
+`deploy-production.yml` runs two ways:
+
+- **Manual (`workflow_dispatch`)** — the promote step. Builds the triggering ref (normally `main` HEAD), deploys to production (through the protected `production` environment → waits for the reviewer), then the `record-snapshot` job force-moves the `production` branch to the deployed commit (`gh api … refs/heads/production`, needs `contents: write`). So **Run workflow** both ships `main` → live *and* records the approved snapshot. No new editor step beyond before.
+- **Scheduled (daily cron `7 4 * * *`, 04:07 UTC)** — rebuilds and redeploys the **`production` branch only**, never `main` HEAD, so un-promoted `main` work can never auto-ship. `record-snapshot` is skipped on scheduled runs.
+
+**Why the daily rebuild exists — scheduled (future-dated) content.** The homepage news strip (`_includes/news-strip.html`) and the News page (`_layouts/page-news.html`) drop items dated after build time; events (`_layouts/page-archive-stacked.html`) already split upcoming/past the same way. A static build only sees the build clock, so a future-dated item stays hidden until *something* rebuilds on/after its date. The cron advances the build clock daily, so a scheduled item surfaces on its due date with no human action.
+
+**Environment split (required setup).** Because the `production` environment requires a reviewer, a scheduled run that used it would block forever waiting for approval. So the workflow selects the environment by trigger: manual → `production` (gated), scheduled → `production-scheduled`. For the cron to actually deploy:
+
+- [ ] Create a **`production-scheduled`** environment (Settings → Environments) with **no required reviewers**.
+- [ ] Ensure `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` are reachable from it — simplest is **repository-level** secrets (work for every environment); if they're scoped to the `production` environment, add them to `production-scheduled` too.
+- [ ] Optionally restrict `production-scheduled`'s deployment branches to `production`.
+
+**Operating it:**
+
+- *Publish content to production*: run `deploy-production` manually (Publish Changes → staging looks good → trigger production → approve). Unchanged, beyond also advancing `production`.
+- *Schedule a news item*: give it a future `date`, publish to `main`, and run a manual production deploy. It records onto `production` while still hidden; the daily cron reveals it on its date. (It won't preview on staging before its date either — staging applies the same filter.)
+- *Trade-off*: the cron redeploys daily even when nothing is due (minor Netlify deploy-history noise; harmless). If it ever matters, gate the deploy step on "an item became due today."
+- *Independence*: `production` is unrelated to `cms-staging`; `reset-cms-staging.yml` does not touch it.
+- *Host migration*: the branch + cron model is host-agnostic — if production moves off Netlify (see "Production hosting migration" below), only the deploy step changes; the `production`-branch gating and the cron stay.
+
 ## CMS appearance & entry-list views
 
 How the admin look-and-feel is configured (all in `admin/config.yml` unless noted):
@@ -184,6 +214,7 @@ When `datadonation.eu`'s production hosting moves off Netlify (planned, separate
 - [ ] Audit `assets/images/` for orphan uploads (images not referenced by any `_data/*.yml`, `_pages/*.md`, or `_events/*.md`). List candidates with a `grep -r` over all content files; manually prune.
 - [ ] Audit active editors and their PATs: any editors no longer involved should have their tokens revoked (org-side) and access removed from the repo collaborator list.
 - [ ] Verify the `reset-cms-staging.yml` workflow is enabled and its recent runs are green (it keeps `cms-staging` in sync with `main` on every push). If it has been failing, reset manually: `git push -f origin main:cms-staging`.
+- [ ] Verify the scheduled `deploy-production.yml` cron runs are green (daily, ~04:07 UTC) and not stuck pending approval — if they're blocked, the `production-scheduled` environment is missing or has a required-reviewer rule (see "Deploy environments & the `production` branch"). Confirm `production` still tracks the last approved deploy: `gh api repos/d3i-website/d3i-website.github.io/git/refs/heads/production --jq .object.sha`.
 - [ ] Verify repo settings haven't drifted from squash-merge-only configuration.
 
 ## Useful commands

--- a/cms/maintainer-notes.md
+++ b/cms/maintainer-notes.md
@@ -41,16 +41,12 @@ Two environments, two workflows:
 
 `deploy-production.yml` runs two ways:
 
-- **Manual (`workflow_dispatch`)** — the promote step. Builds the triggering ref (normally `main` HEAD), deploys to production (through the protected `production` environment → waits for the reviewer), then the `record-snapshot` job force-moves the `production` branch to the deployed commit (`gh api … refs/heads/production`, needs `contents: write`). So **Run workflow** both ships `main` → live *and* records the approved snapshot. No new editor step beyond before.
-- **Scheduled (daily cron `7 4 * * *`, 04:07 UTC)** — rebuilds and redeploys the **`production` branch only**, never `main` HEAD, so un-promoted `main` work can never auto-ship. `record-snapshot` is skipped on scheduled runs.
+- **Manual (`workflow_dispatch`)** — the promote step, and the only path that ships new content. The `deploy-manual` job builds the triggering ref (normally `main` HEAD) and deploys to production through the gated `production` environment (→ waits for the reviewer); then the `record-snapshot` job force-moves the `production` branch to the deployed commit (`gh api … refs/heads/production`, needs `contents: write`). So **Run workflow** both ships `main` → live *and* records the approved snapshot. No new editor step beyond before.
+- **Scheduled (daily cron `7 4 * * *`, 04:07 UTC)** — the `deploy-scheduled` job rebuilds and redeploys the **`production` branch only**, never `main` HEAD, so un-promoted `main` work can never auto-ship. `record-snapshot` doesn't run (it `needs: deploy-manual`, which is skipped on schedule).
 
 **Why the daily rebuild exists — scheduled (future-dated) content.** The homepage news strip (`_includes/news-strip.html`) and the News page (`_layouts/page-news.html`) drop items dated after build time; events (`_layouts/page-archive-stacked.html`) already split upcoming/past the same way. A static build only sees the build clock, so a future-dated item stays hidden until *something* rebuilds on/after its date. The cron advances the build clock daily, so a scheduled item surfaces on its due date with no human action.
 
-**Environment split (required setup).** Because the `production` environment requires a reviewer, a scheduled run that used it would block forever waiting for approval. So the workflow selects the environment by trigger: manual → `production` (gated), scheduled → `production-scheduled`. For the cron to actually deploy:
-
-- [ ] Create a **`production-scheduled`** environment (Settings → Environments) with **no required reviewers**.
-- [ ] Ensure `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` are reachable from it — simplest is **repository-level** secrets (work for every environment); if they're scoped to the `production` environment, add them to `production-scheduled` too.
-- [ ] Optionally restrict `production-scheduled`'s deployment branches to `production`.
+**Why two jobs, not a conditional environment.** The `production` environment requires a reviewer, and a scheduled run that used it would block forever waiting for approval — but an environment's protection is all-or-nothing, and you can't conditionally omit the `environment:` key on one job. So the gate and the auto-path are split into separate jobs: `deploy-manual` uses the gated `production` environment; `deploy-scheduled` uses **no environment** (hence no approval) and authenticates to Netlify with the **repository-level** `NETLIFY_AUTH_TOKEN` / `NETLIFY_SITE_ID` secrets. These are verified repo-level — if they're ever narrowed to environment scope, `deploy-scheduled` loses access and the cron fails to deploy.
 
 **Operating it:**
 
@@ -214,7 +210,7 @@ When `datadonation.eu`'s production hosting moves off Netlify (planned, separate
 - [ ] Audit `assets/images/` for orphan uploads (images not referenced by any `_data/*.yml`, `_pages/*.md`, or `_events/*.md`). List candidates with a `grep -r` over all content files; manually prune.
 - [ ] Audit active editors and their PATs: any editors no longer involved should have their tokens revoked (org-side) and access removed from the repo collaborator list.
 - [ ] Verify the `reset-cms-staging.yml` workflow is enabled and its recent runs are green (it keeps `cms-staging` in sync with `main` on every push). If it has been failing, reset manually: `git push -f origin main:cms-staging`.
-- [ ] Verify the scheduled `deploy-production.yml` cron runs are green (daily, ~04:07 UTC) and not stuck pending approval — if they're blocked, the `production-scheduled` environment is missing or has a required-reviewer rule (see "Deploy environments & the `production` branch"). Confirm `production` still tracks the last approved deploy: `gh api repos/d3i-website/d3i-website.github.io/git/refs/heads/production --jq .object.sha`.
+- [ ] Verify the scheduled `deploy-production.yml` cron runs are green (the `deploy-scheduled` job, daily ~04:07 UTC). If it fails to authenticate to Netlify, check that `NETLIFY_AUTH_TOKEN` / `NETLIFY_SITE_ID` are still **repository-level** secrets (the job uses no environment; see "Deploy environments & the `production` branch"). Confirm `production` still tracks the last approved deploy: `gh api repos/d3i-website/d3i-website.github.io/git/refs/heads/production --jq .object.sha`.
 - [ ] Verify repo settings haven't drifted from squash-merge-only configuration.
 
 ## Useful commands

--- a/index.md
+++ b/index.md
@@ -15,21 +15,21 @@ movements:
   - heading: "What is data donation?"
     image: /assets/images/illustrations/social-media-profile.svg
     image_alt: "A person viewing a social media profile on a screen"
-    body: "Data donation lets people share their personal digital data for research by exercising their legal right of data access. Participants request their data from platforms like Google, Instagram, or TikTok, then donate it to a study."
+    body: "Discover what data donation is all about."
     link:
       url: /data-donation/
       text: "How it works"
   - heading: "Prepare a study"
     image: /assets/images/illustrations/experts.svg
     image_alt: "Researchers collaborating around a search interface"
-    body: "From study design and ethics approval to participant recruitment and data collection, we provide guidance for every stage of preparing a data donation study."
+    body: "Guidance for every stage of preparing your data donation study."
     link:
       url: /prepare-a-study/study-design
       text: "How to run a study"
   - heading: "Free, open-source software"
     image: /assets/images/illustrations/group-project.svg
     image_alt: "A team working together on a project"
-    body: "Port is free, open-source software for collecting donated data. It comes with ready-made scripts for common platforms, runs entirely in the participant's browser, and keeps raw data private."
+    body: "Free, open-source tools for collecting donated data, right in the browser."
     link:
       url: /software/
       text: "Explore the software"

--- a/index.md
+++ b/index.md
@@ -12,24 +12,33 @@ postit:
   link_url: /community/omnibus-letter
   link_text: "Read our letter →"
 movements:
-  - heading: "What is data donation?"
+  - eyebrow: "The method"
+    heading: "What is data donation?"
     image: /assets/images/illustrations/social-media-profile.svg
     image_alt: "A person viewing a social media profile on a screen"
-    body: "Discover what data donation is all about."
+    body: "Data donation allows researchers to collect digital traces by asking participants to donate their own data. Interested?"
+    accent: "#4272EF"
+    tint: "#EEF3FE"
     link:
       url: /data-donation/
-      text: "How it works"
-  - heading: "Prepare a study"
+      text: "Learn how it works"
+  - eyebrow: "For researchers"
+    heading: "Prepare a study"
     image: /assets/images/illustrations/experts.svg
     image_alt: "Researchers collaborating around a search interface"
-    body: "Guidance for every stage of preparing your data donation study."
+    body: "Guidance for preparing your study from design to ethics to FAIR practices."
+    accent: "#FF5E5E"
+    tint: "#FFEFEF"
     link:
       url: /prepare-a-study/study-design
       text: "How to run a study"
-  - heading: "Free, open-source software"
+  - eyebrow: "Open source"
+    heading: "Free, open-source software"
     image: /assets/images/illustrations/group-project.svg
     image_alt: "A team working together on a project"
-    body: "Free, open-source tools for collecting donated data, right in the browser."
+    body: "Free, open-source tools that collect donated data right in the participant's browser."
+    accent: "#E8B53C"
+    tint: "#FDF4DF"
     link:
       url: /software/
       text: "Explore the software"


### PR DESCRIPTION
## News scheduling

Added news scheduling so that news items can be planned, which also means that we had to add a third branch (production) so that we can trigger daily deploys with a github workflow to rebuild. 

Current:
If something's edited in the CMS admin, it saves to branch "cms-staging". When edits are ready, you can click the "publish to staging" button in the CMS, which pushes the changes to the branch "main". That makes it visible on d3i-website.github.io so that we can preview it before it goes live. Then once it's approved, I run the action manually (GitHub actions) to trigger the deploy to Netlify where it's then visible on datadonation.eu.

New:
The manual deploy action now writes it to the production branch first, then deploys to Netlify from there. This allows us to trigger a daily update via a cron job so that the future news items will display on the day they're scheduled to.

## Carousel

We switched the front page to a carousel format to cut down on the text overload and also have it be distinguishable enough from the news underneath it that it looked nice. 

## News pages

Just a small change to the news pages. Previously if you clicked on a news item, it would open to a two-column layout and squish in the right column. This fixes it. 